### PR TITLE
feat: add integration test and fix River startup

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,6 +19,7 @@ func main() {
 
 	dbURL := envOr("DATABASE_URL", "postgres://localhost:5432/releaseguard?sslmode=disable")
 	ghSecret := envOr("GITHUB_WEBHOOK_SECRET", "")
+	addr := envOr("LISTEN_ADDR", ":8080")
 
 	// Database
 	pool, err := db.NewPool(ctx, dbURL)
@@ -60,7 +61,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("POST /webhook/github", webhookHandler)
 
-	srv := &http.Server{Addr: ":8080", Handler: mux}
+	srv := &http.Server{Addr: addr, Handler: mux}
 
 	// Start polling in background
 	go orch.Run(ctx)

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
 )
 
 const schema = `
@@ -26,11 +28,18 @@ CREATE TABLE IF NOT EXISTS subscriptions (
 );
 `
 
-// RunMigrations applies the database schema. Idempotent — safe to call on every startup.
+// RunMigrations applies River's schema and the application schema. Idempotent — safe to call on every startup.
 func RunMigrations(ctx context.Context, pool *pgxpool.Pool) error {
-	_, err := pool.Exec(ctx, schema)
+	migrator, err := rivermigrate.New(riverpgxv5.New(pool), nil)
 	if err != nil {
-		return fmt.Errorf("run migrations: %w", err)
+		return fmt.Errorf("create river migrator: %w", err)
+	}
+	if _, err := migrator.Migrate(ctx, rivermigrate.DirectionUp, nil); err != nil {
+		return fmt.Errorf("river migrations: %w", err)
+	}
+
+	if _, err := pool.Exec(ctx, schema); err != nil {
+		return fmt.Errorf("app migrations: %w", err)
 	}
 	return nil
 }

--- a/internal/queue/client.go
+++ b/internal/queue/client.go
@@ -10,13 +10,12 @@ import (
 // NewRiverClient creates a River client backed by the given pgx pool.
 // Pass nil workers to create an insert-only client (no job processing).
 func NewRiverClient(pool *pgxpool.Pool, workers *river.Workers) (*river.Client[pgx.Tx], error) {
-	config := &river.Config{
-		Queues: map[string]river.QueueConfig{
-			river.QueueDefault: {MaxWorkers: 100},
-		},
-	}
+	config := &river.Config{}
 	if workers != nil {
 		config.Workers = workers
+		config.Queues = map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 100},
+		}
 	}
 	return river.NewClient(riverpgxv5.New(pool), config)
 }

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Integration test for the ingestion layer.
+# Requires: docker, go, curl
+#
+# Spins up Postgres, starts the server, sends a GitHub webhook,
+# verifies the release was persisted, then cleans up.
+
+CONTAINER_NAME="releaseguard-test-pg"
+DB_PORT=5433
+DB_USER="postgres"
+DB_PASS="testpass"
+DB_NAME="releaseguard"
+DATABASE_URL="postgres://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}?sslmode=disable"
+WEBHOOK_SECRET="integration-test-secret"
+SERVER_PORT=8089
+SERVER_PID=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+cleanup() {
+    echo ""
+    echo "--- Cleanup ---"
+    if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        echo "Server stopped"
+    fi
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    echo "Postgres container removed"
+}
+trap cleanup EXIT
+
+fail() {
+    echo -e "${RED}FAIL: $1${NC}" >&2
+    exit 1
+}
+
+pass() {
+    echo -e "${GREEN}PASS: $1${NC}"
+}
+
+# --- 1. Start Postgres ---
+echo "--- Starting Postgres on port $DB_PORT ---"
+docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+docker run -d --name "$CONTAINER_NAME" \
+    -e POSTGRES_DB="$DB_NAME" \
+    -e POSTGRES_PASSWORD="$DB_PASS" \
+    -p "${DB_PORT}:5432" \
+    postgres:16 >/dev/null
+
+echo "Waiting for Postgres..."
+for i in $(seq 1 30); do
+    if docker exec "$CONTAINER_NAME" pg_isready -U "$DB_USER" >/dev/null 2>&1; then
+        echo "Postgres ready"
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        fail "Postgres did not become ready in 30s"
+    fi
+    sleep 1
+done
+
+# --- 2. Build and start server ---
+echo ""
+echo "--- Building server ---"
+go build -o /tmp/releaseguard-test ./cmd/server/
+pass "Build succeeded"
+
+echo ""
+echo "--- Starting server ---"
+DATABASE_URL="$DATABASE_URL" \
+GITHUB_WEBHOOK_SECRET="$WEBHOOK_SECRET" \
+LISTEN_ADDR=":${SERVER_PORT}" \
+    /tmp/releaseguard-test &
+SERVER_PID=$!
+sleep 2
+
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    fail "Server failed to start"
+fi
+pass "Server started (PID $SERVER_PID)"
+
+# --- 3. Send a valid GitHub release webhook ---
+echo ""
+echo "--- Sending GitHub release webhook ---"
+
+PAYLOAD='{"action":"published","release":{"tag_name":"v2.0.0","body":"## Release Notes\n* New feature","prerelease":false,"published_at":"2024-06-01T12:00:00Z"},"repository":{"full_name":"testorg/testrepo"}}'
+
+# Compute HMAC-SHA256 signature
+SIGNATURE=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | awk '{print $NF}')
+
+HTTP_CODE=$(curl -s -o /tmp/webhook-response.txt -w "%{http_code}" \
+    -X POST "http://localhost:${SERVER_PORT}/webhook/github" \
+    -H "Content-Type: application/json" \
+    -H "X-GitHub-Event: release" \
+    -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
+    -d "$PAYLOAD")
+
+if [ "$HTTP_CODE" != "200" ]; then
+    fail "Webhook returned HTTP $HTTP_CODE (expected 200). Body: $(cat /tmp/webhook-response.txt)"
+fi
+pass "Webhook accepted (HTTP 200)"
+
+# Give server a moment to process
+sleep 1
+
+# --- 4. Verify release was persisted ---
+echo ""
+echo "--- Verifying release in database ---"
+
+ROW_COUNT=$(docker exec "$CONTAINER_NAME" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+    "SELECT COUNT(*) FROM releases WHERE repository='testorg/testrepo' AND version='v2.0.0';")
+
+if [ "$ROW_COUNT" != "1" ]; then
+    fail "Expected 1 release row, got: '$ROW_COUNT'"
+fi
+pass "Release persisted in database"
+
+# Verify payload contents
+SOURCE=$(docker exec "$CONTAINER_NAME" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+    "SELECT source FROM releases WHERE repository='testorg/testrepo' AND version='v2.0.0';")
+
+if [ "$SOURCE" != "github" ]; then
+    fail "Expected source='github', got: '$SOURCE'"
+fi
+pass "Release source is correct"
+
+# --- 5. Verify River job was enqueued ---
+echo ""
+echo "--- Verifying River job was enqueued ---"
+
+JOB_COUNT=$(docker exec "$CONTAINER_NAME" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+    "SELECT COUNT(*) FROM river_job WHERE kind='pipeline_process';")
+
+if [ "$JOB_COUNT" -lt 1 ]; then
+    fail "Expected at least 1 River job, got: '$JOB_COUNT'"
+fi
+pass "River pipeline_process job enqueued"
+
+# --- 6. Send duplicate webhook (idempotent skip) ---
+echo ""
+echo "--- Sending duplicate webhook (should be skipped) ---"
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://localhost:${SERVER_PORT}/webhook/github" \
+    -H "Content-Type: application/json" \
+    -H "X-GitHub-Event: release" \
+    -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
+    -d "$PAYLOAD")
+
+if [ "$HTTP_CODE" != "200" ]; then
+    fail "Duplicate webhook returned HTTP $HTTP_CODE (expected 200)"
+fi
+
+sleep 1
+
+ROW_COUNT=$(docker exec "$CONTAINER_NAME" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+    "SELECT COUNT(*) FROM releases WHERE repository='testorg/testrepo' AND version='v2.0.0';")
+
+if [ "$ROW_COUNT" != "1" ]; then
+    fail "Duplicate was not skipped — got $ROW_COUNT rows instead of 1"
+fi
+pass "Duplicate correctly skipped (still 1 row)"
+
+# --- 7. Send webhook with invalid signature ---
+echo ""
+echo "--- Sending webhook with invalid signature ---"
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://localhost:${SERVER_PORT}/webhook/github" \
+    -H "Content-Type: application/json" \
+    -H "X-GitHub-Event: release" \
+    -H "X-Hub-Signature-256: sha256=invalidsignature" \
+    -d "$PAYLOAD")
+
+if [ "$HTTP_CODE" != "403" ]; then
+    fail "Invalid signature returned HTTP $HTTP_CODE (expected 403)"
+fi
+pass "Invalid signature rejected (HTTP 403)"
+
+# --- Done ---
+echo ""
+echo -e "${GREEN}=== All integration tests passed ===${NC}"


### PR DESCRIPTION
## Summary

- Add **River schema migrations** to `RunMigrations()` — River requires its own tables (`river_job`, `river_migration`, etc.) before the client can insert jobs
- Fix **River client factory** — `Queues` cannot be set without `Workers` in River v0.31; insert-only mode now uses empty config
- Make **server listen address** configurable via `LISTEN_ADDR` env var (defaults to `:8080`)
- Add **`scripts/integration-test.sh`** — end-to-end integration test that spins up Postgres in Docker, boots the server, and verifies the full ingestion flow

## Test plan

- [x] `go test ./... -v` — 14 unit tests pass
- [x] `bash scripts/integration-test.sh` — all 7 integration checks pass:
  - Server starts against real Postgres
  - GitHub webhook accepted (HTTP 200)
  - Release persisted in `releases` table
  - Source field correct (`github`)
  - River `pipeline_process` job enqueued
  - Duplicate webhook skipped (idempotent)
  - Invalid HMAC signature rejected (HTTP 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)