### PR TITLE
feat(web): full frontend redesign — editorial aesthetic

### DIFF
--- a/web/app/channels/page.tsx
+++ b/web/app/channels/page.tsx
@@ -118,7 +118,7 @@ export default function ChannelsPage() {
                         fontSize: "11px",
                         fontWeight: 500,
                         textTransform: "uppercase",
-                        letterSpacing: "0.05em",
+                        letterSpacing: "0.08em",
                         color: "#9ca3af",
                         borderBottom: "1px solid #e8e8e5",
                       }}
@@ -158,7 +158,7 @@ export default function ChannelsPage() {
                   <td
                     className="max-w-xs truncate px-5 py-3.5"
                     style={{
-                      fontFamily: "var(--font-jetbrains-mono)",
+                      fontFamily: "'JetBrains Mono', monospace",
                       fontSize: "12px",
                       color: "#6b7280",
                     }}

--- a/web/app/channels/page.tsx
+++ b/web/app/channels/page.tsx
@@ -1,57 +1,208 @@
 "use client";
 
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import Link from "next/link";
 import { channels as channelsApi } from "@/lib/api/client";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Plus } from "lucide-react";
+import { Plus, Pencil, Trash2 } from "lucide-react";
+
+const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
+  slack: { bg: "#4A154B", text: "#ffffff" },
+  discord: { bg: "#5865F2", text: "#ffffff" },
+  webhook: { bg: "#1a1a1a", text: "#ffffff" },
+};
+
+function TypeBadge({ type }: { type: string }) {
+  const colors = TYPE_COLORS[type.toLowerCase()] ?? {
+    bg: "#6b7280",
+    text: "#ffffff",
+  };
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2.5 py-0.5"
+      style={{
+        backgroundColor: colors.bg,
+        color: colors.text,
+        fontFamily: "var(--font-dm-sans)",
+        fontSize: "12px",
+        fontWeight: 500,
+        lineHeight: "16px",
+      }}
+    >
+      {type}
+    </span>
+  );
+}
 
 export default function ChannelsPage() {
   const { data, isLoading } = useSWR("channels", () => channelsApi.list());
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this channel? This cannot be undone.")) return;
+    await channelsApi.delete(id);
+    mutate("channels");
+  };
+
+  const channels = data?.data ?? [];
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">Notification Channels</h2>
-          <p className="text-sm text-muted-foreground">Output targets for release notifications.</p>
-        </div>
-        <Link href="/channels/new"><Button><Plus className="mr-2 h-4 w-4" />Add Channel</Button></Link>
+        <h1
+          style={{
+            fontFamily: "var(--font-fraunces)",
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#111113",
+          }}
+        >
+          Channels
+        </h1>
+        <Link href="/channels/new">
+          <button
+            className="inline-flex items-center gap-1.5 rounded-md px-3.5 py-2 transition-colors hover:opacity-90"
+            style={{
+              backgroundColor: "#e8601a",
+              color: "#ffffff",
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              fontWeight: 500,
+            }}
+          >
+            <Plus className="h-4 w-4" />
+            New Channel
+          </button>
+        </Link>
       </div>
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="py-12 text-center text-muted-foreground">Loading...</div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Config</TableHead>
-                  <TableHead>Created</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data?.data.map((ch) => (
-                  <TableRow key={ch.id}>
-                    <TableCell><Link href={`/channels/${ch.id}/edit`} className="font-medium text-primary hover:underline">{ch.name}</Link></TableCell>
-                    <TableCell><Badge variant="outline">{ch.type}</Badge></TableCell>
-                    <TableCell className="max-w-xs truncate text-xs text-muted-foreground font-mono">
-                      {Object.entries(ch.config).map(([k, v]) => `${k}: ${String(v)}`).join(", ")}
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {new Date(ch.created_at).toLocaleDateString()}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
+
+      {/* Table card */}
+      <div
+        className="overflow-hidden rounded-lg bg-white"
+        style={{ border: "1px solid #e8e8e5" }}
+      >
+        {isLoading ? (
+          <div
+            className="py-16 text-center"
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              color: "#6b7280",
+            }}
+          >
+            Loading...
+          </div>
+        ) : channels.length === 0 ? (
+          <div className="py-16 text-center">
+            <p
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontStyle: "italic",
+                fontSize: "15px",
+                color: "#9ca3af",
+              }}
+            >
+              No notification channels configured yet
+            </p>
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr style={{ backgroundColor: "#fafaf9" }}>
+                {["Name", "Type", "Config", "Created", "Actions"].map(
+                  (heading) => (
+                    <th
+                      key={heading}
+                      className="px-5 py-3 text-left"
+                      style={{
+                        fontFamily: "var(--font-dm-sans)",
+                        fontSize: "11px",
+                        fontWeight: 500,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.05em",
+                        color: "#9ca3af",
+                        borderBottom: "1px solid #e8e8e5",
+                      }}
+                    >
+                      {heading}
+                    </th>
+                  )
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {channels.map((ch) => (
+                <tr
+                  key={ch.id}
+                  className="transition-colors hover:bg-[#fafaf9]"
+                  style={{ borderBottom: "1px solid #e8e8e5" }}
+                >
+                  {/* Name */}
+                  <td
+                    className="px-5 py-3.5"
+                    style={{
+                      fontFamily: "var(--font-dm-sans)",
+                      fontSize: "14px",
+                      fontWeight: 500,
+                      color: "#111113",
+                    }}
+                  >
+                    {ch.name}
+                  </td>
+
+                  {/* Type */}
+                  <td className="px-5 py-3.5">
+                    <TypeBadge type={ch.type} />
+                  </td>
+
+                  {/* Config */}
+                  <td
+                    className="max-w-xs truncate px-5 py-3.5"
+                    style={{
+                      fontFamily: "var(--font-jetbrains-mono)",
+                      fontSize: "12px",
+                      color: "#6b7280",
+                    }}
+                  >
+                    {Object.entries(ch.config)
+                      .map(([k, v]) => `${k}: ${String(v)}`)
+                      .join(", ")}
+                  </td>
+
+                  {/* Created */}
+                  <td
+                    className="px-5 py-3.5"
+                    style={{
+                      fontFamily: "var(--font-dm-sans)",
+                      fontSize: "13px",
+                      color: "#6b7280",
+                    }}
+                  >
+                    {new Date(ch.created_at).toLocaleDateString()}
+                  </td>
+
+                  {/* Actions */}
+                  <td className="px-5 py-3.5">
+                    <div className="flex items-center gap-2">
+                      <Link
+                        href={`/channels/${ch.id}/edit`}
+                        className="rounded p-1 text-[#9ca3af] transition-colors hover:bg-[#f3f3f1] hover:text-[#111113]"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Link>
+                      <button
+                        onClick={() => handleDelete(ch.id)}
+                        className="rounded p-1 text-[#9ca3af] transition-colors hover:bg-red-50 hover:text-red-600"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,124 +1,96 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import "@fontsource/jetbrains-mono/400.css";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-    --radius-sm: calc(var(--radius) - 4px);
-    --radius-md: calc(var(--radius) - 2px);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) + 4px);
-    --radius-2xl: calc(var(--radius) + 8px);
-    --radius-3xl: calc(var(--radius) + 12px);
-    --radius-4xl: calc(var(--radius) + 16px);
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --color-card: var(--card);
-    --color-card-foreground: var(--card-foreground);
-    --color-popover: var(--popover);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-primary: var(--primary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-secondary: var(--secondary);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-muted: var(--muted);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-accent: var(--accent);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-destructive: var(--destructive);
-    --color-border: var(--border);
-    --color-input: var(--input);
-    --color-ring: var(--ring);
-    --color-chart-1: var(--chart-1);
-    --color-chart-2: var(--chart-2);
-    --color-chart-3: var(--chart-3);
-    --color-chart-4: var(--chart-4);
-    --color-chart-5: var(--chart-5);
-    --color-sidebar: var(--sidebar);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-ring: var(--sidebar-ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: #dc2626;
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  /* Design-system extensions */
+  --color-sidebar: var(--sidebar-bg);
+  --color-sidebar-text: var(--sidebar-text);
+  --color-beacon-accent: var(--beacon-accent);
+  --color-mono-bg: var(--mono-bg);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-muted: var(--text-muted);
+  --color-surface: var(--surface);
 }
 
 :root {
-    --radius: 0.625rem;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.646 0.222 41.116);
-    --chart-2: oklch(0.6 0.118 184.704);
-    --chart-3: oklch(0.398 0.07 227.392);
-    --chart-4: oklch(0.828 0.189 84.429);
-    --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
-}
+  --radius: 0.375rem; /* 6px */
 
-.dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+  /* Core layout colors */
+  --background: #fafaf9;
+  --foreground: #111113;
+  --surface: #ffffff;
+  --sidebar-bg: #16181c;
+  --sidebar-text: #9ca3af;
+  --beacon-accent: #e8601a;
+  --border: #e8e8e5;
+  --mono-bg: #f3f3f1;
+  --text-secondary: #6b7280;
+  --text-muted: #9ca3af;
+
+  /* shadcn variable mappings */
+  --card: #ffffff;
+  --card-foreground: #111113;
+  --primary: #e8601a;
+  --primary-foreground: #ffffff;
+  --secondary: #f3f3f1;
+  --secondary-foreground: #374151;
+  --muted: #f3f3f1;
+  --muted-foreground: #6b7280;
+  --accent: #f3f3f1;
+  --accent-foreground: #111113;
+  --input: #e8e8e5;
+  --ring: #e8601a;
+
+  /* Status colors */
+  --status-completed: #16a34a;
+  --status-running: #2563eb;
+  --status-pending: #d97706;
+  --status-failed: #dc2626;
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    }
+  }
   body {
     @apply bg-background text-foreground;
-    }
+    font-family: var(--font-dm-sans), system-ui, sans-serif;
+  }
+}
+
+/* Motion primitives */
+@layer utilities {
+  .fade-in {
+    animation: fadeIn 150ms ease both;
+  }
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,17 +1,20 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Fraunces, DM_Sans } from "next/font/google";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
   subsets: ["latin"],
+  axes: ["SOFT", "WONK"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const dmSans = DM_Sans({
+  variable: "--font-dm-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -26,14 +29,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${fraunces.variable} ${dmSans.variable} antialiased`}>
         <div className="flex h-screen">
           <Sidebar />
           <div className="flex flex-1 flex-col overflow-hidden">
             <Header />
-            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <main className="flex-1 overflow-y-auto p-6 fade-in">{children}</main>
           </div>
         </div>
       </body>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -5,75 +5,174 @@ import useSWR from "swr";
 import Link from "next/link";
 import { StatsCards } from "@/components/dashboard/stats-cards";
 import { RecentReleases } from "@/components/dashboard/recent-releases";
-import { ActivityFeed } from "@/components/dashboard/activity-feed";
-import { projects as projectsApi, semanticReleases as srApi } from "@/lib/api/client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import {
+  projects as projectsApi,
+  semanticReleases as srApi,
+} from "@/lib/api/client";
+import { StatusDot } from "@/components/ui/status-dot";
+import { VersionChip } from "@/components/ui/version-chip";
 import type { SemanticRelease } from "@/lib/api/types";
 
-const statusColors: Record<string, string> = {
-  completed: "bg-green-100 text-green-800",
-  running: "bg-blue-100 text-blue-800",
-  pending: "bg-gray-100 text-gray-800",
-  failed: "bg-red-100 text-red-800",
-};
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
 
-function RecentSemanticReleases() {
-  const { data: projectsData } = useSWR("projects-for-sr-dashboard", () => projectsApi.list());
+interface SRRow extends SemanticRelease {
+  _projectName?: string;
+}
+
+function SemanticReleasesColumn() {
+  const { data: projectsData } = useSWR("projects-for-sr-dashboard", () =>
+    projectsApi.list()
+  );
 
   const { data: allSRs, isLoading } = useSWR(
     projectsData ? "recent-semantic-releases" : null,
     async () => {
       if (!projectsData?.data?.length) return [];
+
+      const projectMap = new Map(
+        projectsData.data.map((p) => [p.id, p.name])
+      );
+
       const results = await Promise.all(
         projectsData.data.slice(0, 10).map((p) =>
           srApi.list(p.id, 1).catch(() => null)
         )
       );
-      return results
+
+      const srs: SRRow[] = results
         .filter((r): r is NonNullable<typeof r> => r !== null)
         .flatMap((r) => r.data)
-        .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-        .slice(0, 6);
+        .sort(
+          (a, b) =>
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        )
+        .slice(0, 6)
+        .map((sr) => ({
+          ...sr,
+          _projectName: projectMap.get(sr.project_id),
+        }));
+
+      return srs;
     }
   );
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Recent Semantic Releases</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div
+      className="rounded-lg bg-white"
+      style={{ border: "1px solid #e8e8e5" }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-5 py-4"
+        style={{ borderBottom: "1px solid #e8e8e5" }}
+      >
+        <h3
+          className="font-medium"
+          style={{
+            fontFamily: "var(--font-dm-sans)",
+            fontSize: "13px",
+            color: "#1a1a1a",
+          }}
+        >
+          Semantic Releases
+        </h3>
+        <Link
+          href="/projects"
+          className="text-sm hover:underline"
+          style={{
+            fontFamily: "var(--font-dm-sans)",
+            fontSize: "13px",
+            color: "#e8601a",
+          }}
+        >
+          View all &rarr;
+        </Link>
+      </div>
+
+      {/* Body */}
+      <div className="p-4 space-y-3">
         {isLoading ? (
-          <div className="py-8 text-center text-muted-foreground">Loading...</div>
-        ) : allSRs && allSRs.length > 0 ? (
-          <div className="space-y-3">
-            {allSRs.map((sr: SemanticRelease) => (
-              <Link
-                key={sr.id}
-                href={`/projects/${sr.project_id}/semantic-releases/${sr.id}`}
-                className="block rounded-md border p-3 transition-colors hover:bg-muted/50"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono font-medium">{sr.version}</span>
-                    <Badge className={statusColors[sr.status] ?? ""}>{sr.status}</Badge>
-                  </div>
-                  <span className="text-xs text-muted-foreground">
-                    {new Date(sr.created_at).toLocaleDateString()}
-                  </span>
-                </div>
-                {sr.report && (
-                  <p className="mt-1 text-sm text-muted-foreground line-clamp-1">{sr.report.summary}</p>
-                )}
-              </Link>
-            ))}
+          <div
+            className="py-8 text-center"
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              color: "#6b7280",
+            }}
+          >
+            Loading...
           </div>
+        ) : allSRs && allSRs.length > 0 ? (
+          allSRs.map((sr: SRRow) => (
+            <Link
+              key={sr.id}
+              href={`/projects/${sr.project_id}/semantic-releases/${sr.id}`}
+              className="block rounded-lg px-4 py-3 transition-colors hover:bg-[#fafaf9]"
+              style={{ border: "1px solid #e8e8e5" }}
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className="font-semibold"
+                  style={{
+                    fontFamily: "var(--font-fraunces)",
+                    fontSize: "15px",
+                    color: "#1a1a1a",
+                  }}
+                >
+                  {sr._projectName ?? "Unknown Project"}
+                </span>
+                <VersionChip version={sr.version} />
+              </div>
+              {sr.report?.summary && (
+                <p
+                  className="mt-1 line-clamp-1"
+                  style={{
+                    fontFamily: "var(--font-dm-sans)",
+                    fontStyle: "italic",
+                    fontSize: "13px",
+                    color: "#6b7280",
+                  }}
+                >
+                  {sr.report.summary}
+                </p>
+              )}
+              <div className="mt-2 flex items-center gap-2">
+                <StatusDot status={sr.status} />
+                <span
+                  style={{
+                    fontFamily: "var(--font-dm-sans)",
+                    fontSize: "12px",
+                    color: "#9ca3af",
+                  }}
+                >
+                  {timeAgo(sr.created_at)}
+                </span>
+              </div>
+            </Link>
+          ))
         ) : (
-          <div className="py-8 text-center text-muted-foreground">No semantic releases yet</div>
+          <div className="py-8 text-center">
+            <p
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontStyle: "italic",
+                fontSize: "14px",
+                color: "#9ca3af",
+              }}
+            >
+              No semantic releases yet
+            </p>
+          </div>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 
@@ -83,9 +182,8 @@ export default function DashboardPage() {
       <StatsCards />
       <div className="grid gap-6 lg:grid-cols-2">
         <RecentReleases />
-        <RecentSemanticReleases />
+        <SemanticReleasesColumn />
       </div>
-      <ActivityFeed />
     </div>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -12,15 +12,7 @@ import {
 import { StatusDot } from "@/components/ui/status-dot";
 import { VersionChip } from "@/components/ui/version-chip";
 import type { SemanticRelease } from "@/lib/api/types";
-
-function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+import { timeAgo } from "@/lib/format";
 
 interface SRRow extends SemanticRelease {
   _projectName?: string;
@@ -78,7 +70,7 @@ function SemanticReleasesColumn() {
           style={{
             fontFamily: "var(--font-dm-sans)",
             fontSize: "13px",
-            color: "#1a1a1a",
+            color: "#111113",
           }}
         >
           Semantic Releases
@@ -123,7 +115,7 @@ function SemanticReleasesColumn() {
                   style={{
                     fontFamily: "var(--font-fraunces)",
                     fontSize: "15px",
-                    color: "#1a1a1a",
+                    color: "#111113",
                   }}
                 >
                   {sr._projectName ?? "Unknown Project"}

--- a/web/app/projects/page.tsx
+++ b/web/app/projects/page.tsx
@@ -3,85 +3,127 @@
 import useSWR from "swr";
 import Link from "next/link";
 import { projects as projectsApi } from "@/lib/api/client";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
+import { timeAgo } from "@/lib/format";
 import { Plus } from "lucide-react";
 
 export default function ProjectsPage() {
   const { data, isLoading } = useSWR("projects", () => projectsApi.list());
+  const items = data?.data ?? [];
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 fade-in">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold">All Projects</h2>
-          <p className="text-sm text-muted-foreground">
-            Manage tracked software projects and their agent configurations.
+          <h1
+            className="text-[24px] font-semibold text-[#111113]"
+            style={{ fontFamily: "var(--font-fraunces)" }}
+          >
+            Projects
+          </h1>
+          <p
+            className="mt-1 text-[13px] text-[#6b7280]"
+            style={{ fontFamily: "var(--font-dm-sans)" }}
+          >
+            Tracked software projects and their agent configurations.
           </p>
         </div>
-        <Link href="/projects/new">
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            New Project
-          </Button>
+        <Link
+          href="/projects/new"
+          className="flex items-center gap-1.5 rounded px-3 py-1.5 text-[13px] text-white transition-opacity hover:opacity-90"
+          style={{ backgroundColor: "#e8601a", fontFamily: "var(--font-dm-sans)" }}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New Project
         </Link>
       </div>
 
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="py-12 text-center text-muted-foreground">Loading...</div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead>Agent Rules</TableHead>
-                  <TableHead>Created</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data?.data.map((project) => (
-                  <TableRow key={project.id}>
-                    <TableCell>
-                      <Link
-                        href={`/projects/${project.id}`}
-                        className="font-medium text-primary hover:underline"
-                      >
-                        {project.name}
-                      </Link>
-                    </TableCell>
-                    <TableCell className="max-w-xs truncate text-muted-foreground">
-                      {project.description}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-1">
-                        {project.agent_rules?.on_major_release && (
-                          <Badge variant="secondary" className="text-xs">major</Badge>
-                        )}
-                        {project.agent_rules?.on_minor_release && (
-                          <Badge variant="secondary" className="text-xs">minor</Badge>
-                        )}
-                        {project.agent_rules?.on_security_patch && (
-                          <Badge variant="secondary" className="text-xs">security</Badge>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {new Date(project.created_at).toLocaleDateString()}
-                    </TableCell>
-                  </TableRow>
+      <div
+        className="overflow-hidden rounded-md"
+        style={{ border: "1px solid #e8e8e5", backgroundColor: "#ffffff" }}
+      >
+        {isLoading ? (
+          <p
+            className="px-4 py-8 text-center text-[14px] italic text-[#9ca3af]"
+            style={{ fontFamily: "var(--font-fraunces)" }}
+          >
+            Loading…
+          </p>
+        ) : items.length === 0 ? (
+          <p
+            className="px-4 py-8 text-center text-[14px] italic text-[#9ca3af]"
+            style={{ fontFamily: "var(--font-fraunces)" }}
+          >
+            No projects yet — create one to start tracking releases
+          </p>
+        ) : (
+          <table className="w-full text-[13px]" style={{ fontFamily: "var(--font-dm-sans)" }}>
+            <thead>
+              <tr style={{ borderBottom: "1px solid #e8e8e5", backgroundColor: "#fafaf9" }}>
+                {["Name", "Description", "Agent Rules", "Created"].map((h) => (
+                  <th
+                    key={h}
+                    className="px-4 py-2.5 text-left text-[11px] font-medium uppercase tracking-[0.08em] text-[#9ca3af]"
+                  >
+                    {h}
+                  </th>
                 ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((project, i) => (
+                <tr
+                  key={project.id}
+                  className="transition-colors duration-100 hover:bg-[#fafaf9]"
+                  style={i > 0 ? { borderTop: "1px solid #e8e8e5" } : undefined}
+                >
+                  <td className="px-4 py-2.5">
+                    <Link
+                      href={`/projects/${project.id}`}
+                      className="font-medium text-[#e8601a] hover:underline"
+                    >
+                      {project.name}
+                    </Link>
+                  </td>
+                  <td className="max-w-[280px] truncate px-4 py-2.5 text-[#6b7280]">
+                    {project.description || "—"}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <div className="flex flex-wrap gap-1">
+                      {project.agent_rules?.on_major_release && (
+                        <span
+                          className="rounded-full px-2 py-0.5 text-[11px] font-medium"
+                          style={{ backgroundColor: "#f3f3f1", color: "#374151" }}
+                        >
+                          major
+                        </span>
+                      )}
+                      {project.agent_rules?.on_minor_release && (
+                        <span
+                          className="rounded-full px-2 py-0.5 text-[11px] font-medium"
+                          style={{ backgroundColor: "#f3f3f1", color: "#374151" }}
+                        >
+                          minor
+                        </span>
+                      )}
+                      {project.agent_rules?.on_security_patch && (
+                        <span
+                          className="rounded-full px-2 py-0.5 text-[11px] font-medium"
+                          style={{ backgroundColor: "#f3f3f1", color: "#374151" }}
+                        >
+                          security
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5 text-[12px] text-[#9ca3af]">
+                    {timeAgo(project.created_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/app/releases/page.tsx
+++ b/web/app/releases/page.tsx
@@ -12,19 +12,7 @@ import { ProviderBadge } from "@/components/ui/provider-badge";
 import { VersionChip } from "@/components/ui/version-chip";
 import type { Release, Source, Project } from "@/lib/api/types";
 
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
-
-function timeAgo(dateStr?: string | null): string {
-  if (!dateStr) return "\u2014";
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+import { timeAgo } from "@/lib/format";
 
 interface ReleaseRow extends Release {
   _projectName?: string;
@@ -133,7 +121,7 @@ export default function ReleasesPage() {
           fontFamily: "var(--font-fraunces)",
           fontSize: "24px",
           fontWeight: 700,
-          color: "#1a1a1a",
+          color: "#111113",
         }}
       >
         Releases
@@ -151,7 +139,7 @@ export default function ReleasesPage() {
           style={{
             fontFamily: "var(--font-dm-sans)",
             fontSize: "13px",
-            color: "#1a1a1a",
+            color: "#111113",
             border: "1px solid #e8e8e5",
           }}
           onFocus={(e) =>
@@ -211,7 +199,7 @@ export default function ReleasesPage() {
                         fontSize: "11px",
                         fontWeight: 600,
                         textTransform: "uppercase" as const,
-                        letterSpacing: "0.05em",
+                        letterSpacing: "0.08em",
                         color: "#9ca3af",
                       }}
                     >
@@ -237,7 +225,7 @@ export default function ReleasesPage() {
                         style={{
                           fontFamily: "var(--font-dm-sans)",
                           fontSize: "13px",
-                          color: "#1a1a1a",
+                          color: "#111113",
                           fontWeight: 500,
                         }}
                       >

--- a/web/app/releases/page.tsx
+++ b/web/app/releases/page.tsx
@@ -3,132 +3,369 @@
 import { useState } from "react";
 import useSWR from "swr";
 import Link from "next/link";
-import { releases as releasesApi, projects as projectsApi } from "@/lib/api/client";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from "@/components/ui/select";
-import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from "@/components/ui/table";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+  releases as releasesApi,
+  projects as projectsApi,
+  sources as sourcesApi,
+} from "@/lib/api/client";
+import { ProviderBadge } from "@/components/ui/provider-badge";
+import { VersionChip } from "@/components/ui/version-chip";
+import type { Release, Source, Project } from "@/lib/api/types";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function timeAgo(dateStr?: string | null): string {
+  if (!dateStr) return "\u2014";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+interface ReleaseRow extends Release {
+  _projectName?: string;
+  _projectId?: string;
+  _provider?: string;
+  _repository?: string;
+}
+
+const PER_PAGE = 15;
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
 
 export default function ReleasesPage() {
   const [page, setPage] = useState(1);
   const [projectFilter, setProjectFilter] = useState<string>("all");
 
-  const { data: projectsData } = useSWR("projects-for-filter", () => projectsApi.list());
-
-  const { data, isLoading } = useSWR(
-    ["releases", page, projectFilter],
-    () => {
-      if (projectFilter !== "all") {
-        return releasesApi.listByProject(projectFilter, page);
-      }
-      // When no project filter, show all releases across all projects
-      // The API doesn't have a global releases endpoint, so we use the first project or show empty
-      return null;
-    }
+  /* Fetch projects for the filter dropdown + source enrichment */
+  const { data: projectsData } = useSWR("projects-for-filter", () =>
+    projectsApi.list()
   );
 
-  // For the "all projects" case, we need to fetch all project releases
-  const { data: allReleasesData } = useSWR(
-    projectFilter === "all" ? ["all-releases", page] : null,
+  /* Build a map: sourceId -> { provider, repository, projectName, projectId } */
+  const { data: sourceMap } = useSWR(
+    projectsData ? "source-map-for-releases" : null,
     async () => {
-      if (!projectsData?.data?.length) return null;
-      // Fetch releases from the first project as a default view
-      // In production, there would be a global /releases endpoint
-      const results = await Promise.all(
-        projectsData.data.slice(0, 5).map((p) => releasesApi.listByProject(p.id, page).catch(() => null))
+      if (!projectsData?.data?.length) return new Map<string, { provider: string; repository: string; projectName: string; projectId: string }>();
+      const map = new Map<string, { provider: string; repository: string; projectName: string; projectId: string }>();
+      await Promise.all(
+        projectsData.data.map(async (p: Project) => {
+          const res = await sourcesApi.listByProject(p.id).catch(() => null);
+          if (res?.data) {
+            for (const s of res.data) {
+              map.set(s.id, {
+                provider: s.provider,
+                repository: s.repository,
+                projectName: p.name,
+                projectId: p.id,
+              });
+            }
+          }
+        })
       );
-      const allReleases = results
-        .filter((r): r is NonNullable<typeof r> => r !== null)
-        .flatMap((r) => r.data);
-      return allReleases;
+      return map;
     }
   );
 
-  const displayReleases = projectFilter !== "all" ? data?.data : allReleasesData;
-  const total = data?.meta?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / 15));
+  /* Fetch releases — scoped by project or aggregated across all */
+  const { data: scopedData, isLoading: scopedLoading } = useSWR(
+    projectFilter !== "all" ? ["releases", page, projectFilter] : null,
+    () => releasesApi.listByProject(projectFilter, page)
+  );
+
+  const { data: allReleasesData, isLoading: allLoading } = useSWR(
+    projectFilter === "all" && projectsData
+      ? ["all-releases", page]
+      : null,
+    async () => {
+      if (!projectsData?.data?.length) return [];
+      const results = await Promise.all(
+        projectsData.data.map((p: Project) =>
+          releasesApi.listByProject(p.id, page).catch(() => null)
+        )
+      );
+      return results
+        .filter((r): r is NonNullable<typeof r> => r !== null)
+        .flatMap((r) => r.data)
+        .sort(
+          (a, b) =>
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+    }
+  );
+
+  const isLoading = projectFilter !== "all" ? scopedLoading : allLoading;
+
+  /* Enrich releases with source metadata */
+  const rawReleases: Release[] =
+    projectFilter !== "all"
+      ? scopedData?.data ?? []
+      : allReleasesData ?? [];
+
+  const releases: ReleaseRow[] = rawReleases.map((r) => {
+    const info = sourceMap?.get(r.source_id);
+    return {
+      ...r,
+      _projectName: info?.projectName,
+      _projectId: info?.projectId,
+      _provider: info?.provider,
+      _repository: info?.repository,
+    };
+  });
+
+  /* Pagination math */
+  const total = projectFilter !== "all" ? (scopedData?.meta?.total ?? 0) : releases.length;
+  const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
+  const startRow = (page - 1) * PER_PAGE + 1;
+  const endRow = Math.min(page * PER_PAGE, total);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      {/* Page title */}
+      <h1
+        style={{
+          fontFamily: "var(--font-fraunces)",
+          fontSize: "24px",
+          fontWeight: 700,
+          color: "#1a1a1a",
+        }}
+      >
+        Releases
+      </h1>
+
+      {/* Project filter */}
       <div>
-        <h2 className="text-lg font-semibold">All Releases</h2>
-        <p className="text-sm text-muted-foreground">Browse releases ingested from all sources.</p>
+        <select
+          value={projectFilter}
+          onChange={(e) => {
+            setProjectFilter(e.target.value);
+            setPage(1);
+          }}
+          className="appearance-none rounded-md bg-white px-3 py-2 pr-8 outline-none transition-shadow"
+          style={{
+            fontFamily: "var(--font-dm-sans)",
+            fontSize: "13px",
+            color: "#1a1a1a",
+            border: "1px solid #e8e8e5",
+          }}
+          onFocus={(e) =>
+            (e.currentTarget.style.boxShadow = "0 0 0 2px #e8601a40")
+          }
+          onBlur={(e) => (e.currentTarget.style.boxShadow = "none")}
+        >
+          <option value="all">All Projects</option>
+          {projectsData?.data.map((p: Project) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
       </div>
 
-      {/* Filters */}
-      <div className="flex gap-3">
-        <Select value={projectFilter} onValueChange={(v) => { setProjectFilter(v); setPage(1); }}>
-          <SelectTrigger className="w-48">
-            <SelectValue placeholder="All Projects" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Projects</SelectItem>
-            {projectsData?.data.map((p) => (
-              <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="py-12 text-center text-muted-foreground">Loading...</div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Version</TableHead>
-                  <TableHead>Source</TableHead>
-                  <TableHead>Released</TableHead>
-                  <TableHead>Ingested</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {(displayReleases ?? []).map((release) => (
-                  <TableRow key={release.id}>
-                    <TableCell>
+      {/* Table card */}
+      <div
+        className="overflow-hidden rounded-lg bg-white"
+        style={{ border: "1px solid #e8e8e5" }}
+      >
+        {isLoading ? (
+          <div
+            className="py-16 text-center"
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              color: "#6b7280",
+            }}
+          >
+            Loading...
+          </div>
+        ) : releases.length === 0 ? (
+          <div className="py-16 text-center">
+            <p
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontStyle: "italic",
+                fontSize: "15px",
+                color: "#9ca3af",
+              }}
+            >
+              No releases ingested yet
+            </p>
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr style={{ borderBottom: "1px solid #e8e8e5", backgroundColor: "#fafaf9" }}>
+                {["Project", "Provider", "Repository", "Version", "Released", "Age"].map(
+                  (col) => (
+                    <th
+                      key={col}
+                      className="px-4 py-3 text-left"
+                      style={{
+                        fontFamily: "var(--font-dm-sans)",
+                        fontSize: "11px",
+                        fontWeight: 600,
+                        textTransform: "uppercase" as const,
+                        letterSpacing: "0.05em",
+                        color: "#9ca3af",
+                      }}
+                    >
+                      {col}
+                    </th>
+                  )
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {releases.map((release) => (
+                <tr
+                  key={release.id}
+                  className="transition-colors hover:bg-[#fafaf9]"
+                  style={{ borderBottom: "1px solid #e8e8e5" }}
+                >
+                  {/* Project */}
+                  <td className="px-4 py-3">
+                    {release._projectId ? (
                       <Link
-                        href={`/releases/${release.id}`}
-                        className="font-mono text-sm text-primary hover:underline"
+                        href={`/projects/${release._projectId}`}
+                        className="hover:underline"
+                        style={{
+                          fontFamily: "var(--font-dm-sans)",
+                          fontSize: "13px",
+                          color: "#1a1a1a",
+                          fontWeight: 500,
+                        }}
                       >
-                        {release.version}
+                        {release._projectName ?? "\u2014"}
                       </Link>
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground font-mono">
-                      {release.source_id}
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {release.released_at ? new Date(release.released_at).toLocaleDateString() : "\u2014"}
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {new Date(release.created_at).toLocaleDateString()}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
+                    ) : (
+                      <span
+                        style={{
+                          fontFamily: "var(--font-dm-sans)",
+                          fontSize: "13px",
+                          color: "#9ca3af",
+                        }}
+                      >
+                        {"\u2014"}
+                      </span>
+                    )}
+                  </td>
+
+                  {/* Provider */}
+                  <td className="px-4 py-3">
+                    {release._provider ? (
+                      <ProviderBadge provider={release._provider} />
+                    ) : (
+                      <span
+                        style={{
+                          fontFamily: "var(--font-dm-sans)",
+                          fontSize: "13px",
+                          color: "#9ca3af",
+                        }}
+                      >
+                        {"\u2014"}
+                      </span>
+                    )}
+                  </td>
+
+                  {/* Repository */}
+                  <td className="px-4 py-3">
+                    <span
+                      style={{
+                        fontFamily: "'JetBrains Mono', monospace",
+                        fontSize: "12px",
+                        color: "#374151",
+                      }}
+                    >
+                      {release._repository ?? release.source_id}
+                    </span>
+                  </td>
+
+                  {/* Version */}
+                  <td className="px-4 py-3">
+                    <Link href={`/releases/${release.id}`}>
+                      <VersionChip version={release.version} />
+                    </Link>
+                  </td>
+
+                  {/* Released date */}
+                  <td className="px-4 py-3">
+                    <span
+                      style={{
+                        fontFamily: "var(--font-dm-sans)",
+                        fontSize: "13px",
+                        color: "#6b7280",
+                      }}
+                    >
+                      {release.released_at
+                        ? new Date(release.released_at).toLocaleDateString()
+                        : "\u2014"}
+                    </span>
+                  </td>
+
+                  {/* Age */}
+                  <td className="px-4 py-3">
+                    <span
+                      style={{
+                        fontFamily: "var(--font-dm-sans)",
+                        fontSize: "13px",
+                        color: "#9ca3af",
+                      }}
+                    >
+                      {timeAgo(release.released_at ?? release.created_at)}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
 
       {/* Pagination */}
-      {projectFilter !== "all" && totalPages > 1 && (
+      {total > 0 && (
         <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">{total} releases</span>
+          <span
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              color: "#9ca3af",
+            }}
+          >
+            {startRow}&ndash;{endRow} of {total}
+          </span>
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage(page - 1)}>
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <span className="text-sm">Page {page} of {totalPages}</span>
-            <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
-              <ChevronRight className="h-4 w-4" />
-            </Button>
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+              className="rounded-md bg-white px-3 py-1.5 transition-colors hover:bg-[#fafaf9] disabled:cursor-not-allowed disabled:opacity-40"
+              style={{
+                fontFamily: "var(--font-dm-sans)",
+                fontSize: "13px",
+                color: "#374151",
+                border: "1px solid #e8e8e5",
+              }}
+            >
+              Previous
+            </button>
+            <button
+              disabled={page >= totalPages}
+              onClick={() => setPage(page + 1)}
+              className="rounded-md bg-white px-3 py-1.5 transition-colors hover:bg-[#fafaf9] disabled:cursor-not-allowed disabled:opacity-40"
+              style={{
+                fontFamily: "var(--font-dm-sans)",
+                fontSize: "13px",
+                color: "#374151",
+                border: "1px solid #e8e8e5",
+              }}
+            >
+              Next
+            </button>
           </div>
         </div>
       )}

--- a/web/app/subscriptions/page.tsx
+++ b/web/app/subscriptions/page.tsx
@@ -1,67 +1,213 @@
 "use client";
 
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import Link from "next/link";
-import { subscriptions as subsApi, channels as channelsApi } from "@/lib/api/client";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Plus } from "lucide-react";
+import {
+  subscriptions as subsApi,
+  channels as channelsApi,
+} from "@/lib/api/client";
+import { Plus, Pencil, Trash2 } from "lucide-react";
+
+const SUB_TYPE_COLORS: Record<string, { bg: string; text: string }> = {
+  source: { bg: "#1a1a1a", text: "#ffffff" },
+  project: { bg: "#2563eb", text: "#ffffff" },
+};
+
+function SubTypeBadge({ type }: { type: string }) {
+  const colors = SUB_TYPE_COLORS[type] ?? { bg: "#6b7280", text: "#ffffff" };
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2.5 py-0.5"
+      style={{
+        backgroundColor: colors.bg,
+        color: colors.text,
+        fontFamily: "var(--font-dm-sans)",
+        fontSize: "12px",
+        fontWeight: 500,
+        lineHeight: "16px",
+      }}
+    >
+      {type}
+    </span>
+  );
+}
 
 export default function SubscriptionsPage() {
   const { data, isLoading } = useSWR("subscriptions", () => subsApi.list());
-  const { data: channelsData } = useSWR("channels-for-sub-list", () => channelsApi.list());
+  const { data: channelsData } = useSWR("channels-for-sub-list", () =>
+    channelsApi.list()
+  );
 
-  const getChannelName = (id: string) => channelsData?.data.find((c) => c.id === id)?.name ?? id;
+  const getChannelName = (id: string) =>
+    channelsData?.data.find((c) => c.id === id)?.name ?? id;
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this subscription? This cannot be undone.")) return;
+    await subsApi.delete(id);
+    mutate("subscriptions");
+  };
+
+  const subscriptions = data?.data ?? [];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">Subscriptions</h2>
-          <p className="text-sm text-muted-foreground">Notification routing rules linking sources or projects to channels.</p>
-        </div>
-        <Link href="/subscriptions/new"><Button><Plus className="mr-2 h-4 w-4" />New Subscription</Button></Link>
+        <h1
+          style={{
+            fontFamily: "var(--font-fraunces)",
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#111113",
+          }}
+        >
+          Subscriptions
+        </h1>
+        <Link href="/subscriptions/new">
+          <button
+            className="inline-flex items-center gap-1.5 rounded-md px-3.5 py-2 transition-colors hover:opacity-90"
+            style={{
+              backgroundColor: "#e8601a",
+              color: "#ffffff",
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              fontWeight: 500,
+            }}
+          >
+            <Plus className="h-4 w-4" />
+            New Subscription
+          </button>
+        </Link>
       </div>
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="py-12 text-center text-muted-foreground">Loading...</div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Target</TableHead>
-                  <TableHead>Channel</TableHead>
-                  <TableHead>Version Filter</TableHead>
-                  <TableHead>Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data?.data.map((sub) => (
-                  <TableRow key={sub.id}>
-                    <TableCell>
-                      <Badge variant="outline">{sub.type}</Badge>
-                    </TableCell>
-                    <TableCell className="font-mono text-xs text-muted-foreground">
-                      {sub.type === "source" ? sub.source_id : sub.project_id}
-                    </TableCell>
-                    <TableCell>{getChannelName(sub.channel_id)}</TableCell>
-                    <TableCell className="font-mono text-xs text-muted-foreground">{sub.version_filter || "\u2014"}</TableCell>
-                    <TableCell>
-                      <Link href={`/subscriptions/${sub.id}/edit`}>
-                        <Badge variant="secondary" className="cursor-pointer">edit</Badge>
+
+      {/* Table card */}
+      <div
+        className="overflow-hidden rounded-lg bg-white"
+        style={{ border: "1px solid #e8e8e5" }}
+      >
+        {isLoading ? (
+          <div
+            className="py-16 text-center"
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              color: "#6b7280",
+            }}
+          >
+            Loading...
+          </div>
+        ) : subscriptions.length === 0 ? (
+          <div className="py-16 text-center">
+            <p
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontStyle: "italic",
+                fontSize: "15px",
+                color: "#9ca3af",
+              }}
+            >
+              No subscriptions configured yet
+            </p>
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr style={{ backgroundColor: "#fafaf9" }}>
+                {["Type", "Target", "Channel", "Version Filter", "Actions"].map(
+                  (heading) => (
+                    <th
+                      key={heading}
+                      className="px-5 py-3 text-left"
+                      style={{
+                        fontFamily: "var(--font-dm-sans)",
+                        fontSize: "11px",
+                        fontWeight: 500,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.05em",
+                        color: "#9ca3af",
+                        borderBottom: "1px solid #e8e8e5",
+                      }}
+                    >
+                      {heading}
+                    </th>
+                  )
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {subscriptions.map((sub) => (
+                <tr
+                  key={sub.id}
+                  className="transition-colors hover:bg-[#fafaf9]"
+                  style={{ borderBottom: "1px solid #e8e8e5" }}
+                >
+                  {/* Type */}
+                  <td className="px-5 py-3.5">
+                    <SubTypeBadge type={sub.type} />
+                  </td>
+
+                  {/* Target */}
+                  <td
+                    className="px-5 py-3.5"
+                    style={{
+                      fontFamily: "var(--font-dm-sans)",
+                      fontSize: "14px",
+                      fontWeight: 500,
+                      color: "#111113",
+                    }}
+                  >
+                    {sub.type === "source" ? sub.source_id : sub.project_id}
+                  </td>
+
+                  {/* Channel */}
+                  <td
+                    className="px-5 py-3.5"
+                    style={{
+                      fontFamily: "var(--font-dm-sans)",
+                      fontSize: "14px",
+                      color: "#111113",
+                    }}
+                  >
+                    {getChannelName(sub.channel_id)}
+                  </td>
+
+                  {/* Version Filter */}
+                  <td
+                    className="px-5 py-3.5"
+                    style={{
+                      fontFamily: sub.version_filter
+                        ? "var(--font-jetbrains-mono)"
+                        : "var(--font-dm-sans)",
+                      fontSize: "13px",
+                      color: sub.version_filter ? "#111113" : "#9ca3af",
+                    }}
+                  >
+                    {sub.version_filter || "\u2014"}
+                  </td>
+
+                  {/* Actions */}
+                  <td className="px-5 py-3.5">
+                    <div className="flex items-center gap-2">
+                      <Link
+                        href={`/subscriptions/${sub.id}/edit`}
+                        className="rounded p-1 text-[#9ca3af] transition-colors hover:bg-[#f3f3f1] hover:text-[#111113]"
+                      >
+                        <Pencil className="h-4 w-4" />
                       </Link>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
+                      <button
+                        onClick={() => handleDelete(sub.id)}
+                        className="rounded p-1 text-[#9ca3af] transition-colors hover:bg-red-50 hover:text-red-600"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/app/subscriptions/page.tsx
+++ b/web/app/subscriptions/page.tsx
@@ -123,7 +123,7 @@ export default function SubscriptionsPage() {
                         fontSize: "11px",
                         fontWeight: 500,
                         textTransform: "uppercase",
-                        letterSpacing: "0.05em",
+                        letterSpacing: "0.08em",
                         color: "#9ca3af",
                         borderBottom: "1px solid #e8e8e5",
                       }}
@@ -176,7 +176,7 @@ export default function SubscriptionsPage() {
                     className="px-5 py-3.5"
                     style={{
                       fontFamily: sub.version_filter
-                        ? "var(--font-jetbrains-mono)"
+                        ? "'JetBrains Mono', monospace"
                         : "var(--font-dm-sans)",
                       fontSize: "13px",
                       color: sub.version_filter ? "#111113" : "#9ca3af",

--- a/web/components/dashboard/recent-releases.tsx
+++ b/web/components/dashboard/recent-releases.tsx
@@ -3,67 +3,173 @@
 
 import useSWR from "swr";
 import Link from "next/link";
-import { projects as projectsApi, releases as releasesApi } from "@/lib/api/client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type { Release } from "@/lib/api/types";
+import {
+  projects as projectsApi,
+  releases as releasesApi,
+  sources as sourcesApi,
+} from "@/lib/api/client";
+import { VersionChip } from "@/components/ui/version-chip";
+import type { Release, Source } from "@/lib/api/types";
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+interface ReleaseRow extends Release {
+  _repository?: string;
+}
 
 export function RecentReleases() {
-  const { data: projectsData } = useSWR("projects-for-dashboard", () => projectsApi.list());
+  const { data: projectsData } = useSWR("projects-for-dashboard", () =>
+    projectsApi.list()
+  );
 
   const { data: allReleases, isLoading } = useSWR(
     projectsData ? "recent-releases" : null,
     async () => {
       if (!projectsData?.data?.length) return [];
-      const results = await Promise.all(
-        projectsData.data.slice(0, 10).map((p) =>
-          releasesApi.listByProject(p.id, 1).catch(() => null)
-        )
-      );
-      return results
+
+      // Fetch releases and sources in parallel per project
+      const projectSlice = projectsData.data.slice(0, 10);
+      const [releaseResults, sourceResults] = await Promise.all([
+        Promise.all(
+          projectSlice.map((p) =>
+            releasesApi.listByProject(p.id, 1).catch(() => null)
+          )
+        ),
+        Promise.all(
+          projectSlice.map((p) =>
+            sourcesApi.listByProject(p.id, 1).catch(() => null)
+          )
+        ),
+      ]);
+
+      // Build source_id -> repository map
+      const sourceMap = new Map<string, string>();
+      sourceResults
         .filter((r): r is NonNullable<typeof r> => r !== null)
         .flatMap((r) => r.data)
-        .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-        .slice(0, 8);
+        .forEach((s: Source) => sourceMap.set(s.id, s.repository));
+
+      const releases: ReleaseRow[] = releaseResults
+        .filter((r): r is NonNullable<typeof r> => r !== null)
+        .flatMap((r) => r.data)
+        .sort(
+          (a, b) =>
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        )
+        .slice(0, 8)
+        .map((rel) => ({
+          ...rel,
+          _repository: sourceMap.get(rel.source_id),
+        }));
+
+      return releases;
     }
   );
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>Recent Releases</CardTitle>
-        <Link href="/releases" className="text-sm text-primary hover:underline">
-          View all
+    <div
+      className="rounded-lg bg-white"
+      style={{ border: "1px solid #e8e8e5" }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-5 py-4"
+        style={{ borderBottom: "1px solid #e8e8e5" }}
+      >
+        <h3
+          className="font-medium"
+          style={{
+            fontFamily: "var(--font-dm-sans)",
+            fontSize: "13px",
+            color: "#1a1a1a",
+          }}
+        >
+          Recent Source Releases
+        </h3>
+        <Link
+          href="/releases"
+          className="text-sm hover:underline"
+          style={{
+            fontFamily: "var(--font-dm-sans)",
+            fontSize: "13px",
+            color: "#e8601a",
+          }}
+        >
+          View all &rarr;
         </Link>
-      </CardHeader>
-      <CardContent>
+      </div>
+
+      {/* Body */}
+      <div>
         {isLoading ? (
-          <div className="py-8 text-center text-muted-foreground">Loading...</div>
-        ) : allReleases && allReleases.length > 0 ? (
-          <div className="space-y-3">
-            {allReleases.map((release: Release) => (
-              <Link
-                key={release.id}
-                href={`/releases/${release.id}`}
-                className="flex items-center justify-between rounded-md border p-3 transition-colors hover:bg-muted/50"
-              >
-                <div className="min-w-0 flex-1">
-                  <span className="font-mono text-sm font-medium">{release.version}</span>
-                  <div className="mt-1 text-xs text-muted-foreground">
-                    {release.released_at
-                      ? new Date(release.released_at).toLocaleDateString()
-                      : new Date(release.created_at).toLocaleDateString()}
-                  </div>
-                </div>
-                <span className="text-xs text-muted-foreground font-mono">
-                  {release.source_id.slice(0, 8)}...
-                </span>
-              </Link>
-            ))}
+          <div
+            className="py-12 text-center"
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              color: "#6b7280",
+            }}
+          >
+            Loading...
           </div>
+        ) : allReleases && allReleases.length > 0 ? (
+          allReleases.map((release: ReleaseRow, idx: number) => (
+            <div
+              key={release.id}
+              className="flex items-center justify-between px-5 py-3"
+              style={
+                idx < allReleases.length - 1
+                  ? { borderBottom: "1px solid #e8e8e5" }
+                  : undefined
+              }
+            >
+              <span
+                className="min-w-0 flex-1 truncate"
+                style={{
+                  fontFamily: "'JetBrains Mono', monospace",
+                  fontSize: "13px",
+                  color: "#6b7280",
+                }}
+              >
+                {release._repository ?? release.source_id.slice(0, 12)}
+              </span>
+              <div className="ml-3 flex items-center gap-3">
+                <VersionChip version={release.version} />
+                <span
+                  className="whitespace-nowrap"
+                  style={{
+                    fontFamily: "var(--font-dm-sans)",
+                    fontSize: "12px",
+                    color: "#9ca3af",
+                  }}
+                >
+                  {timeAgo(release.released_at ?? release.created_at)}
+                </span>
+              </div>
+            </div>
+          ))
         ) : (
-          <div className="py-8 text-center text-muted-foreground">No releases yet</div>
+          <div className="py-12 text-center">
+            <p
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontStyle: "italic",
+                fontSize: "14px",
+                color: "#9ca3af",
+              }}
+            >
+              No releases yet
+            </p>
+          </div>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/web/components/dashboard/recent-releases.tsx
+++ b/web/components/dashboard/recent-releases.tsx
@@ -10,15 +10,7 @@ import {
 } from "@/lib/api/client";
 import { VersionChip } from "@/components/ui/version-chip";
 import type { Release, Source } from "@/lib/api/types";
-
-function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+import { timeAgo } from "@/lib/format";
 
 interface ReleaseRow extends Release {
   _repository?: string;
@@ -88,7 +80,7 @@ export function RecentReleases() {
           style={{
             fontFamily: "var(--font-dm-sans)",
             fontSize: "13px",
-            color: "#1a1a1a",
+            color: "#111113",
           }}
         >
           Recent Source Releases
@@ -121,9 +113,10 @@ export function RecentReleases() {
           </div>
         ) : allReleases && allReleases.length > 0 ? (
           allReleases.map((release: ReleaseRow, idx: number) => (
-            <div
+            <Link
               key={release.id}
-              className="flex items-center justify-between px-5 py-3"
+              href={`/releases/${release.id}`}
+              className="flex items-center justify-between px-5 py-3 transition-colors hover:bg-[#fafaf9]"
               style={
                 idx < allReleases.length - 1
                   ? { borderBottom: "1px solid #e8e8e5" }
@@ -153,7 +146,7 @@ export function RecentReleases() {
                   {timeAgo(release.released_at ?? release.created_at)}
                 </span>
               </div>
-            </div>
+            </Link>
           ))
         ) : (
           <div className="py-12 text-center">

--- a/web/components/dashboard/stats-cards.tsx
+++ b/web/components/dashboard/stats-cards.tsx
@@ -3,7 +3,7 @@
 
 import useSWR from "swr";
 import { system } from "@/lib/api/client";
-import { Package, Radio, Clock, AlertTriangle } from "lucide-react";
+import { Package, Radio, Clock, FolderKanban } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 interface StatItem {
@@ -20,7 +20,7 @@ export function StatsCards() {
     { label: "Total Releases", value: stats?.total_releases ?? "\u2014", icon: Package },
     { label: "Active Sources", value: stats?.total_sources ?? "\u2014", icon: Radio },
     { label: "Pending Jobs", value: stats?.pending_agent_runs ?? "\u2014", icon: Clock },
-    { label: "Total Projects", value: stats?.total_projects ?? "\u2014", icon: AlertTriangle },
+    { label: "Total Projects", value: stats?.total_projects ?? "\u2014", icon: FolderKanban },
   ];
 
   return (
@@ -36,7 +36,7 @@ export function StatsCards() {
             style={{ color: "#b0b0a8" }}
           />
           <p
-            className="text-xs uppercase tracking-wide"
+            className="text-xs uppercase tracking-[0.08em]"
             style={{
               fontFamily: "var(--font-dm-sans)",
               fontSize: "12px",
@@ -51,7 +51,7 @@ export function StatsCards() {
               fontFamily: "var(--font-fraunces)",
               fontSize: "32px",
               lineHeight: 1.1,
-              color: "#1a1a1a",
+              color: "#111113",
             }}
           >
             {isLoading ? "\u00B7\u00B7\u00B7" : item.value}

--- a/web/components/dashboard/stats-cards.tsx
+++ b/web/components/dashboard/stats-cards.tsx
@@ -3,32 +3,60 @@
 
 import useSWR from "swr";
 import { system } from "@/lib/api/client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { FolderKanban, Radio, Package, Bot } from "lucide-react";
+import { Package, Radio, Clock, AlertTriangle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface StatItem {
+  label: string;
+  value: number | string;
+  icon: LucideIcon;
+}
 
 export function StatsCards() {
   const { data, isLoading } = useSWR("stats", () => system.stats());
 
   const stats = data?.data;
-  const items = [
-    { label: "Projects", value: stats?.total_projects ?? "\u2014", icon: FolderKanban, color: "text-blue-600" },
-    { label: "Sources", value: stats?.total_sources ?? "\u2014", icon: Radio, color: "text-green-600" },
-    { label: "Releases", value: stats?.total_releases ?? "\u2014", icon: Package, color: "text-purple-600" },
-    { label: "Pending Agent Runs", value: stats?.pending_agent_runs ?? "\u2014", icon: Bot, color: "text-yellow-600" },
+  const items: StatItem[] = [
+    { label: "Total Releases", value: stats?.total_releases ?? "\u2014", icon: Package },
+    { label: "Active Sources", value: stats?.total_sources ?? "\u2014", icon: Radio },
+    { label: "Pending Jobs", value: stats?.pending_agent_runs ?? "\u2014", icon: Clock },
+    { label: "Total Projects", value: stats?.total_projects ?? "\u2014", icon: AlertTriangle },
   ];
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {items.map((item) => (
-        <Card key={item.label}>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">{item.label}</CardTitle>
-            <item.icon className={`h-4 w-4 ${item.color}`} />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{isLoading ? "..." : item.value}</div>
-          </CardContent>
-        </Card>
+        <div
+          key={item.label}
+          className="relative rounded-lg bg-white px-5 py-4"
+          style={{ border: "1px solid #e8e8e5" }}
+        >
+          <item.icon
+            className="absolute right-4 top-4 h-4 w-4"
+            style={{ color: "#b0b0a8" }}
+          />
+          <p
+            className="text-xs uppercase tracking-wide"
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "12px",
+              color: "#6b7280",
+            }}
+          >
+            {item.label}
+          </p>
+          <p
+            className="mt-1 font-bold"
+            style={{
+              fontFamily: "var(--font-fraunces)",
+              fontSize: "32px",
+              lineHeight: 1.1,
+              color: "#1a1a1a",
+            }}
+          >
+            {isLoading ? "\u00B7\u00B7\u00B7" : item.value}
+          </p>
+        </div>
       ))}
     </div>
   );

--- a/web/components/layout/header.tsx
+++ b/web/components/layout/header.tsx
@@ -1,25 +1,50 @@
-// web/components/layout/header.tsx
 "use client";
 
 import { usePathname } from "next/navigation";
 
-const titles: Record<string, string> = {
-  "/": "Dashboard",
-  "/projects": "Projects",
-  "/releases": "Releases",
-  "/sources": "Sources",
-  "/subscriptions": "Subscriptions",
-  "/channels": "Channels",
+const SEGMENT_LABELS: Record<string, string> = {
+  "": "Dashboard",
+  projects: "Projects",
+  releases: "Releases",
+  sources: "Sources",
+  subscriptions: "Subscriptions",
+  channels: "Channels",
+  agent: "Agent",
+  "semantic-releases": "Semantic Releases",
+  "context-sources": "Context Sources",
+  new: "New",
+  edit: "Edit",
 };
+
+function segmentLabel(seg: string): string {
+  return SEGMENT_LABELS[seg] ?? seg;
+}
 
 export function Header() {
   const pathname = usePathname();
-  const segment = "/" + (pathname.split("/")[1] ?? "");
-  const title = titles[segment] ?? "ReleaseBeacon";
+  const segments = pathname.split("/").filter(Boolean);
+
+  const uuidRe = /^[0-9a-f-]{8,}$/i;
+  const breadcrumbs = segments
+    .filter((s) => !uuidRe.test(s))
+    .map(segmentLabel);
+
+  const display =
+    breadcrumbs.length === 0
+      ? "Dashboard"
+      : breadcrumbs.join(" / ");
 
   return (
-    <header className="flex h-14 items-center border-b px-6">
-      <h1 className="text-lg font-semibold">{title}</h1>
+    <header
+      className="flex h-12 items-center px-6"
+      style={{ borderBottom: "1px solid #e8e8e5", backgroundColor: "#ffffff" }}
+    >
+      <p
+        className="text-[14px] font-medium text-[#111113]"
+        style={{ fontFamily: "var(--font-dm-sans)" }}
+      >
+        {display}
+      </p>
     </header>
   );
 }

--- a/web/components/layout/sidebar.tsx
+++ b/web/components/layout/sidebar.tsx
@@ -1,53 +1,49 @@
-// web/components/layout/sidebar.tsx
 "use client";
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
-  LayoutDashboard, FolderKanban, Package, Radio,
-  Bell, Megaphone, ChevronLeft, ChevronRight,
+  LayoutDashboard,
+  FolderKanban,
+  Package,
+  Bell,
+  Megaphone,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useState } from "react";
 
 const navItems = [
   { href: "/", label: "Dashboard", icon: LayoutDashboard },
   { href: "/projects", label: "Projects", icon: FolderKanban },
   { href: "/releases", label: "Releases", icon: Package },
-  { href: "/sources", label: "Sources", icon: Radio },
-  { href: "/subscriptions", label: "Subscriptions", icon: Bell },
   { href: "/channels", label: "Channels", icon: Megaphone },
+  { href: "/subscriptions", label: "Subscriptions", icon: Bell },
 ];
 
 export function Sidebar() {
   const pathname = usePathname();
-  const [collapsed, setCollapsed] = useState(false);
 
   return (
     <aside
-      className={cn(
-        "flex flex-col border-r bg-muted/30 transition-all duration-200",
-        collapsed ? "w-16" : "w-56"
-      )}
+      className="flex w-[200px] shrink-0 flex-col"
+      style={{ backgroundColor: "#16181c" }}
     >
-      <div className="flex h-14 items-center border-b px-4">
-        {!collapsed && (
-          <Link href="/" className="flex items-center gap-2 font-semibold">
-            <Package className="h-5 w-5 text-primary" />
-            <span>ReleaseBeacon</span>
-          </Link>
-        )}
-        <button
-          onClick={() => setCollapsed(!collapsed)}
-          className={cn(
-            "ml-auto rounded-md p-1 hover:bg-muted",
-            collapsed && "mx-auto"
-          )}
+      {/* Logo */}
+      <div className="flex h-12 items-center gap-2 px-4">
+        <span
+          className="h-2.5 w-2.5 rounded-full shrink-0"
+          style={{ backgroundColor: "#e8601a" }}
+        />
+        <Link
+          href="/"
+          className="text-[16px] italic text-white"
+          style={{ fontFamily: "var(--font-fraunces)" }}
         >
-          {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
-        </button>
+          ReleaseBeacon
+        </Link>
       </div>
-      <nav className="flex-1 space-y-1 p-2">
+
+      {/* Nav */}
+      <nav className="flex-1 px-0 pt-2">
         {navItems.map((item) => {
           const isActive =
             item.href === "/"
@@ -58,14 +54,23 @@ export function Sidebar() {
               key={item.href}
               href={item.href}
               className={cn(
-                "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                "flex items-center gap-3 py-2 pl-4 pr-3 text-[13px] transition-colors duration-150",
                 isActive
-                  ? "bg-primary/10 text-primary font-medium"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  ? "text-white"
+                  : "text-[#9ca3af] hover:text-white"
               )}
+              style={
+                isActive
+                  ? {
+                      borderLeft: "3px solid #e8601a",
+                      backgroundColor: "rgba(255,255,255,0.06)",
+                      paddingLeft: "13px",
+                    }
+                  : { borderLeft: "3px solid transparent" }
+              }
             >
               <item.icon className="h-4 w-4 shrink-0" />
-              {!collapsed && <span>{item.label}</span>}
+              <span style={{ fontFamily: "var(--font-dm-sans)" }}>{item.label}</span>
             </Link>
           );
         })}

--- a/web/components/projects/project-detail.tsx
+++ b/web/components/projects/project-detail.tsx
@@ -4,14 +4,23 @@ import useSWR from "swr";
 import Link from "next/link";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { projects as projectsApi, sources as sourcesApi, contextSources as ctxApi, semanticReleases as srApi, agent as agentApi } from "@/lib/api/client";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Pencil, Trash2, ArrowLeft, Play, Bot, Radio, BookOpen, FileText } from "lucide-react";
+import {
+  projects as projectsApi,
+  sources as sourcesApi,
+  contextSources as ctxApi,
+  semanticReleases as srApi,
+  agent as agentApi,
+} from "@/lib/api/client";
+import type { AgentRules } from "@/lib/api/types";
+import { ProviderBadge } from "@/components/ui/provider-badge";
+import { StatusDot } from "@/components/ui/status-dot";
+import { VersionChip } from "@/components/ui/version-chip";
+import { SectionLabel } from "@/components/ui/section-label";
+import { Pencil, Trash2, Play, Plus } from "lucide-react";
+
+/* ---------- Tabs ---------- */
 
 const tabs = [
-  { key: "overview", label: "Overview" },
   { key: "sources", label: "Sources" },
   { key: "context", label: "Context Sources" },
   { key: "semantic", label: "Semantic Releases" },
@@ -20,16 +29,82 @@ const tabs = [
 
 type TabKey = (typeof tabs)[number]["key"];
 
+/* ---------- Helpers ---------- */
+
+function formatDuration(startedAt?: string, completedAt?: string): string {
+  if (!startedAt) return "--";
+  const start = new Date(startedAt).getTime();
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now();
+  const secs = Math.round((end - start) / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return `${mins}m ${rem}s`;
+}
+
+function truncate(str: string, max: number): string {
+  return str.length > max ? str.slice(0, max) + "\u2026" : str;
+}
+
+function formatInterval(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  return `${(seconds / 3600).toFixed(1)}h`;
+}
+
+/* ---------- Urgency chip ---------- */
+
+const URGENCY_COLORS: Record<string, { bg: string; text: string }> = {
+  critical: { bg: "#dc2626", text: "#ffffff" },
+  high: { bg: "#f97316", text: "#ffffff" },
+};
+
+function UrgencyChip({ urgency }: { urgency: string }) {
+  const u = urgency.toLowerCase();
+  const style = URGENCY_COLORS[u];
+  if (!style) return null;
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium leading-none"
+      style={{ backgroundColor: style.bg, color: style.text }}
+    >
+      {urgency}
+    </span>
+  );
+}
+
+/* ---------- Main component ---------- */
+
 export function ProjectDetail({ id }: { id: string }) {
   const router = useRouter();
-  const [activeTab, setActiveTab] = useState<TabKey>("overview");
-  const { data, isLoading } = useSWR(`project-${id}`, () => projectsApi.get(id));
-  const { data: sourcesData } = useSWR(activeTab === "sources" ? `project-${id}-sources` : null, () => sourcesApi.listByProject(id));
-  const { data: ctxData } = useSWR(activeTab === "context" ? `project-${id}-ctx` : null, () => ctxApi.list(id));
-  const { data: srData } = useSWR(activeTab === "semantic" ? `project-${id}-sr` : null, () => srApi.list(id));
-  const { data: runsData, mutate: mutateRuns } = useSWR(activeTab === "agent" ? `project-${id}-runs` : null, () => agentApi.listRuns(id));
+  const [activeTab, setActiveTab] = useState<TabKey>("sources");
   const [triggering, setTriggering] = useState(false);
 
+  /* Agent config local state */
+  const [promptDraft, setPromptDraft] = useState<string | null>(null);
+  const [rulesDraft, setRulesDraft] = useState<AgentRules | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  /* Data fetching */
+  const { data, isLoading, mutate: mutateProject } = useSWR(`project-${id}`, () => projectsApi.get(id));
+  const { data: sourcesData, mutate: mutateSources } = useSWR(
+    activeTab === "sources" ? `project-${id}-sources` : null,
+    () => sourcesApi.listByProject(id),
+  );
+  const { data: ctxData, mutate: mutateCtx } = useSWR(
+    activeTab === "context" ? `project-${id}-ctx` : null,
+    () => ctxApi.list(id),
+  );
+  const { data: srData } = useSWR(
+    activeTab === "semantic" ? `project-${id}-sr` : null,
+    () => srApi.list(id),
+  );
+  const { data: runsData, mutate: mutateRuns } = useSWR(
+    activeTab === "agent" ? `project-${id}-runs` : null,
+    () => agentApi.listRuns(id),
+  );
+
+  /* Handlers */
   const handleDelete = async () => {
     if (!confirm("Delete this project? This will cascade to sources and subscriptions.")) return;
     await projectsApi.delete(id);
@@ -46,279 +121,543 @@ export function ProjectDetail({ id }: { id: string }) {
     }
   };
 
-  if (isLoading) return <div className="py-12 text-center text-muted-foreground">Loading...</div>;
+  const handleDeleteSource = async (sourceId: string) => {
+    if (!confirm("Delete this source?")) return;
+    await sourcesApi.delete(sourceId);
+    mutateSources();
+  };
+
+  const handleDeleteCtx = async (ctxId: string) => {
+    if (!confirm("Delete this context source?")) return;
+    await ctxApi.delete(ctxId);
+    mutateCtx();
+  };
+
+  const handleSaveAgentConfig = async () => {
+    if (!project) return;
+    setSaving(true);
+    try {
+      const input = {
+        name: project.name,
+        description: project.description,
+        agent_prompt: promptDraft ?? project.agent_prompt,
+        agent_rules: rulesDraft ?? project.agent_rules,
+      };
+      await projectsApi.update(id, input);
+      mutateProject();
+      setPromptDraft(null);
+      setRulesDraft(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /* Loading / not found states */
+  if (isLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center" style={{ color: "#9ca3af" }}>
+        Loading...
+      </div>
+    );
+  }
 
   const project = data?.data;
-  if (!project) return <div className="py-12 text-center">Project not found</div>;
+  if (!project) {
+    return (
+      <div className="flex h-48 items-center justify-center" style={{ color: "#6b7280" }}>
+        Project not found
+      </div>
+    );
+  }
+
+  /* Derived counts */
+  const sourceCount = sourcesData?.data?.length;
+  const ctxCount = ctxData?.data?.length;
+
+  /* Current effective values */
+  const currentPrompt = promptDraft ?? project.agent_prompt ?? "";
+  const currentRules: AgentRules = rulesDraft ?? project.agent_rules ?? {};
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Link href="/projects">
-          <Button variant="ghost" size="sm">
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back
-          </Button>
-        </Link>
-      </div>
+    <div className="space-y-0">
+      {/* ===== Header zone ===== */}
+      <div
+        className="-m-6 mb-0 border-b px-6 py-5"
+        style={{ backgroundColor: "#ffffff", borderColor: "#e8e8e5" }}
+      >
+        <div className="flex items-start justify-between">
+          {/* Left: project info */}
+          <div className="min-w-0 flex-1">
+            <h1
+              className="text-[28px] font-bold leading-tight"
+              style={{ fontFamily: "var(--font-fraunces), serif" }}
+            >
+              {project.name}
+            </h1>
+            {project.description && (
+              <p
+                className="mt-1 text-[14px]"
+                style={{ fontFamily: "var(--font-dm-sans), sans-serif", color: "#6b7280" }}
+              >
+                {project.description}
+              </p>
+            )}
+            <p
+              className="mt-2 text-[12px]"
+              style={{ fontFamily: "var(--font-dm-sans), sans-serif", color: "#9ca3af" }}
+            >
+              {sourceCount !== undefined ? `${sourceCount} sources` : "-- sources"}
+              {" \u00B7 "}
+              {ctxCount !== undefined ? `${ctxCount} context sources` : "-- context sources"}
+            </p>
+          </div>
 
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 className="text-2xl font-bold">{project.name}</h2>
-          {project.description && <p className="mt-1 text-muted-foreground">{project.description}</p>}
-        </div>
-        <div className="flex gap-2">
-          <Link href={`/projects/${id}/edit`}>
-            <Button variant="outline" size="sm">
-              <Pencil className="mr-2 h-4 w-4" /> Edit
-            </Button>
-          </Link>
-          <Button variant="destructive" size="sm" onClick={handleDelete}>
-            <Trash2 className="mr-2 h-4 w-4" /> Delete
-          </Button>
-        </div>
-      </div>
-
-      {/* Tab bar */}
-      <div className="flex gap-1 border-b">
-        {tabs.map((tab) => (
-          <button
-            key={tab.key}
-            onClick={() => setActiveTab(tab.key)}
-            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === tab.key
-                ? "border-primary text-primary"
-                : "border-transparent text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Tab content */}
-      {activeTab === "overview" && (
-        <div className="grid gap-6 lg:grid-cols-2">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Agent Configuration</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {project.agent_prompt ? (
-                <div>
-                  <div className="text-xs text-muted-foreground mb-1">Custom Prompt</div>
-                  <pre className="rounded bg-muted p-3 text-sm whitespace-pre-wrap">{project.agent_prompt}</pre>
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No custom agent prompt configured.</p>
-              )}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Agent Rules</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {project.agent_rules ? (
-                <div className="space-y-2 text-sm">
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Major releases</span>
-                    <Badge variant={project.agent_rules.on_major_release ? "default" : "secondary"}>
-                      {project.agent_rules.on_major_release ? "enabled" : "disabled"}
-                    </Badge>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Minor releases</span>
-                    <Badge variant={project.agent_rules.on_minor_release ? "default" : "secondary"}>
-                      {project.agent_rules.on_minor_release ? "enabled" : "disabled"}
-                    </Badge>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Security patches</span>
-                    <Badge variant={project.agent_rules.on_security_patch ? "default" : "secondary"}>
-                      {project.agent_rules.on_security_patch ? "enabled" : "disabled"}
-                    </Badge>
-                  </div>
-                  {project.agent_rules.version_pattern && (
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Version pattern</span>
-                      <span className="font-mono text-xs">{project.agent_rules.version_pattern}</span>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No agent rules configured.</p>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-      )}
-
-      {activeTab === "sources" && (
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Radio className="h-4 w-4" /> Sources
-            </CardTitle>
-            <Link href={`/projects/${id}/sources/new`}>
-              <Button variant="outline" size="sm">Add Source</Button>
+          {/* Right: actions */}
+          <div className="flex shrink-0 items-center gap-2 ml-4">
+            <Link href={`/projects/${id}/edit`}>
+              <button
+                className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors hover:bg-[#f3f3f1]"
+                style={{
+                  fontFamily: "var(--font-dm-sans), sans-serif",
+                  borderColor: "#e8e8e5",
+                  color: "#374151",
+                }}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                Edit
+              </button>
             </Link>
-          </CardHeader>
-          <CardContent>
+            <button
+              onClick={handleDelete}
+              className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors hover:bg-red-50"
+              style={{
+                fontFamily: "var(--font-dm-sans), sans-serif",
+                borderColor: "#dc2626",
+                color: "#dc2626",
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete
+            </button>
+            <button
+              onClick={handleTriggerRun}
+              disabled={triggering}
+              className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[13px] font-medium text-white transition-colors disabled:opacity-60"
+              style={{
+                fontFamily: "var(--font-dm-sans), sans-serif",
+                backgroundColor: "#e8601a",
+              }}
+            >
+              <Play className="h-3.5 w-3.5" />
+              {triggering ? "Running..." : "Run Agent"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* ===== Tab bar ===== */}
+      <div
+        className="-mx-6 border-b px-6"
+        style={{ borderColor: "#e8e8e5", backgroundColor: "#ffffff" }}
+      >
+        <div className="flex gap-0">
+          {tabs.map((tab) => {
+            const isActive = activeTab === tab.key;
+            return (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className="relative px-4 py-2.5 text-[13px] font-medium transition-colors"
+                style={{
+                  fontFamily: "var(--font-dm-sans), sans-serif",
+                  color: isActive ? "#111113" : "#9ca3af",
+                }}
+              >
+                {tab.label}
+                {isActive && (
+                  <span
+                    className="absolute bottom-0 left-4 right-4 h-[2px]"
+                    style={{ backgroundColor: "#e8601a" }}
+                  />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ===== Tab content ===== */}
+      <div className="pt-6">
+        {/* --- Sources tab --- */}
+        {activeTab === "sources" && (
+          <div>
+            <div className="mb-4 flex items-center justify-between">
+              <SectionLabel>Sources</SectionLabel>
+              <Link href={`/projects/${id}/sources/new`}>
+                <button
+                  className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors hover:bg-[#f3f3f1]"
+                  style={{
+                    fontFamily: "var(--font-dm-sans), sans-serif",
+                    borderColor: "#e8e8e5",
+                    color: "#374151",
+                  }}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add Source
+                </button>
+              </Link>
+            </div>
+
             {sourcesData?.data && sourcesData.data.length > 0 ? (
-              <div className="space-y-2">
-                {sourcesData.data.map((source) => (
-                  <Link
-                    key={source.id}
-                    href={`/sources/${source.id}/edit`}
-                    className="flex items-center justify-between rounded-md border p-3 hover:bg-muted/50"
-                  >
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline">{source.provider}</Badge>
-                        <span className="font-mono text-sm">{source.repository}</span>
-                      </div>
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        Poll every {source.poll_interval_seconds}s
-                        {source.last_polled_at && ` · Last: ${new Date(source.last_polled_at).toLocaleString()}`}
-                      </div>
-                    </div>
-                    <Badge variant={source.enabled ? "default" : "secondary"}>
-                      {source.enabled ? "active" : "disabled"}
-                    </Badge>
-                  </Link>
-                ))}
+              <div className="overflow-hidden rounded-md border" style={{ borderColor: "#e8e8e5" }}>
+                <table className="w-full text-[13px]" style={{ fontFamily: "var(--font-dm-sans), sans-serif" }}>
+                  <thead>
+                    <tr style={{ backgroundColor: "#fafaf9" }}>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Provider</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Repository</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Interval</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Status</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Last polled</th>
+                      <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sourcesData.data.map((source) => (
+                      <tr key={source.id} className="border-t" style={{ borderColor: "#e8e8e5" }}>
+                        <td className="px-4 py-3">
+                          <ProviderBadge provider={source.provider} />
+                        </td>
+                        <td className="px-4 py-3">
+                          <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: "12px" }}>
+                            {source.repository}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3" style={{ color: "#6b7280" }}>
+                          {formatInterval(source.poll_interval_seconds)}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <StatusDot status={source.enabled ? "completed" : "pending"} />
+                            <span style={{ color: source.enabled ? "#16a34a" : "#d97706" }}>
+                              {source.enabled ? "Active" : "Disabled"}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3" style={{ color: "#9ca3af" }}>
+                          {source.last_polled_at
+                            ? new Date(source.last_polled_at).toLocaleString()
+                            : "Never"}
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <button
+                            onClick={() => handleDeleteSource(source.id)}
+                            className="text-[12px] font-medium transition-colors hover:text-[#dc2626]"
+                            style={{ color: "#9ca3af" }}
+                          >
+                            Delete
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             ) : (
-              <p className="py-4 text-center text-sm text-muted-foreground">No sources configured</p>
+              <div
+                className="flex h-32 items-center justify-center rounded-md border text-[13px]"
+                style={{ borderColor: "#e8e8e5", color: "#9ca3af" }}
+              >
+                No sources configured
+              </div>
             )}
-          </CardContent>
-        </Card>
-      )}
+          </div>
+        )}
 
-      {activeTab === "context" && (
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <BookOpen className="h-4 w-4" /> Context Sources
-            </CardTitle>
-            <Link href={`/projects/${id}/context-sources/new`}>
-              <Button variant="outline" size="sm">Add Context Source</Button>
-            </Link>
-          </CardHeader>
-          <CardContent>
+        {/* --- Context Sources tab --- */}
+        {activeTab === "context" && (
+          <div>
+            <div className="mb-4 flex items-center justify-between">
+              <SectionLabel>Context Sources</SectionLabel>
+              <Link href={`/projects/${id}/context-sources/new`}>
+                <button
+                  className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors hover:bg-[#f3f3f1]"
+                  style={{
+                    fontFamily: "var(--font-dm-sans), sans-serif",
+                    borderColor: "#e8e8e5",
+                    color: "#374151",
+                  }}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add Context Source
+                </button>
+              </Link>
+            </div>
+
             {ctxData?.data && ctxData.data.length > 0 ? (
-              <div className="space-y-2">
-                {ctxData.data.map((ctx) => (
-                  <div key={ctx.id} className="flex items-center justify-between rounded-md border p-3">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline">{ctx.type}</Badge>
-                        <span className="font-medium text-sm">{ctx.name}</span>
-                      </div>
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        Created {new Date(ctx.created_at).toLocaleDateString()}
-                      </div>
-                    </div>
-                  </div>
-                ))}
+              <div className="overflow-hidden rounded-md border" style={{ borderColor: "#e8e8e5" }}>
+                <table className="w-full text-[13px]" style={{ fontFamily: "var(--font-dm-sans), sans-serif" }}>
+                  <thead>
+                    <tr style={{ backgroundColor: "#fafaf9" }}>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Type</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Name</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Config URL</th>
+                      <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {ctxData.data.map((ctx) => (
+                      <tr key={ctx.id} className="border-t" style={{ borderColor: "#e8e8e5" }}>
+                        <td className="px-4 py-3">
+                          <span
+                            className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium leading-none"
+                            style={{ backgroundColor: "#f3f3f1", color: "#374151" }}
+                          >
+                            {ctx.type}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 font-medium" style={{ color: "#111113" }}>
+                          {ctx.name}
+                        </td>
+                        <td className="px-4 py-3" style={{ color: "#9ca3af" }}>
+                          <span
+                            className="text-[12px]"
+                            style={{ fontFamily: "'JetBrains Mono', monospace" }}
+                            title={typeof ctx.config?.url === "string" ? ctx.config.url : ""}
+                          >
+                            {typeof ctx.config?.url === "string"
+                              ? truncate(ctx.config.url, 50)
+                              : "--"}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <button
+                            onClick={() => handleDeleteCtx(ctx.id)}
+                            className="text-[12px] font-medium transition-colors hover:text-[#dc2626]"
+                            style={{ color: "#9ca3af" }}
+                          >
+                            Delete
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             ) : (
-              <p className="py-4 text-center text-sm text-muted-foreground">No context sources configured</p>
+              <div
+                className="flex h-32 items-center justify-center rounded-md border text-[13px]"
+                style={{ borderColor: "#e8e8e5", color: "#9ca3af" }}
+              >
+                No context sources configured
+              </div>
             )}
-          </CardContent>
-        </Card>
-      )}
+          </div>
+        )}
 
-      {activeTab === "semantic" && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <FileText className="h-4 w-4" /> Semantic Releases
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
+        {/* --- Semantic Releases tab --- */}
+        {activeTab === "semantic" && (
+          <div>
+            <SectionLabel className="mb-4">Semantic Releases</SectionLabel>
+
             {srData?.data && srData.data.length > 0 ? (
               <div className="space-y-3">
                 {srData.data.map((sr) => (
                   <Link
                     key={sr.id}
                     href={`/projects/${id}/semantic-releases/${sr.id}`}
-                    className="block rounded-md border p-4 hover:bg-muted/50"
+                    className="block rounded-md border p-4 transition-colors hover:bg-[#fafaf9]"
+                    style={{ borderColor: "#e8e8e5" }}
                   >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <span className="font-mono font-medium">{sr.version}</span>
-                        <Badge
-                          variant={sr.status === "completed" ? "default" : sr.status === "failed" ? "destructive" : "secondary"}
-                        >
-                          {sr.status}
-                        </Badge>
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        {new Date(sr.created_at).toLocaleDateString()}
+                    <div className="flex items-center gap-2.5">
+                      <VersionChip version={sr.version} />
+                      <StatusDot status={sr.status} />
+                      <span className="text-[13px]" style={{ color: "#6b7280" }}>
+                        {sr.status}
                       </span>
+                      {sr.report?.urgency && <UrgencyChip urgency={sr.report.urgency} />}
                     </div>
-                    {sr.report && (
-                      <p className="mt-2 text-sm text-muted-foreground line-clamp-2">{sr.report.summary}</p>
+                    {sr.report?.summary && (
+                      <p
+                        className="mt-2 text-[13px] italic leading-relaxed"
+                        style={{ color: "#6b7280" }}
+                      >
+                        {truncate(sr.report.summary, 200)}
+                      </p>
                     )}
                   </Link>
                 ))}
               </div>
             ) : (
-              <p className="py-4 text-center text-sm text-muted-foreground">No semantic releases yet</p>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      {activeTab === "agent" && (
-        <div className="space-y-6">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <CardTitle className="flex items-center gap-2 text-base">
-                <Bot className="h-4 w-4" /> Agent
-              </CardTitle>
-              <Button size="sm" onClick={handleTriggerRun} disabled={triggering}>
-                <Play className="mr-2 h-4 w-4" />
-                {triggering ? "Triggering..." : "Trigger Run"}
-              </Button>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                <h4 className="text-sm font-medium">Run History</h4>
-                {runsData?.data && runsData.data.length > 0 ? (
-                  <div className="space-y-2">
-                    {runsData.data.map((run) => (
-                      <div key={run.id} className="flex items-center justify-between rounded-md border p-3">
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <Badge
-                              variant={run.status === "completed" ? "default" : run.status === "failed" ? "destructive" : "secondary"}
-                            >
-                              {run.status}
-                            </Badge>
-                            <span className="text-sm text-muted-foreground">{run.trigger}</span>
-                          </div>
-                          {run.error && (
-                            <p className="mt-1 text-xs text-red-600">{run.error}</p>
-                          )}
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {run.started_at ? new Date(run.started_at).toLocaleString() : "Pending"}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="py-4 text-center text-sm text-muted-foreground">No agent runs yet</p>
-                )}
+              <div
+                className="flex h-32 items-center justify-center rounded-md border text-[13px]"
+                style={{ borderColor: "#e8e8e5", color: "#9ca3af" }}
+              >
+                No semantic releases yet
               </div>
-            </CardContent>
-          </Card>
-        </div>
-      )}
+            )}
+          </div>
+        )}
+
+        {/* --- Agent tab --- */}
+        {activeTab === "agent" && (
+          <div className="space-y-8">
+            {/* Prompt section */}
+            <div>
+              <SectionLabel className="mb-3">Agent Prompt</SectionLabel>
+              <textarea
+                value={currentPrompt}
+                onChange={(e) => setPromptDraft(e.target.value)}
+                rows={5}
+                placeholder="Custom instructions for the agent when analyzing releases..."
+                className="w-full resize-y rounded-md border px-3 py-2 text-[13px] placeholder:text-[#9ca3af] focus:outline-none focus:ring-1"
+                style={{
+                  fontFamily: "var(--font-dm-sans), sans-serif",
+                  backgroundColor: "#fafaf9",
+                  borderColor: "#e8e8e5",
+                  color: "#111113",
+                }}
+              />
+              <div className="mt-2 flex justify-end">
+                <button
+                  onClick={handleSaveAgentConfig}
+                  disabled={saving || (promptDraft === null && rulesDraft === null)}
+                  className="rounded-md px-3 py-1.5 text-[13px] font-medium text-white transition-colors disabled:opacity-40"
+                  style={{ backgroundColor: "#e8601a" }}
+                >
+                  {saving ? "Saving..." : "Save"}
+                </button>
+              </div>
+            </div>
+
+            {/* Rules section */}
+            <div>
+              <SectionLabel className="mb-3">Trigger Rules</SectionLabel>
+              <div className="space-y-3">
+                <label className="flex items-center gap-2.5 text-[13px]" style={{ color: "#374151" }}>
+                  <input
+                    type="checkbox"
+                    checked={currentRules.on_major_release ?? false}
+                    onChange={(e) =>
+                      setRulesDraft({ ...currentRules, on_major_release: e.target.checked })
+                    }
+                    className="h-4 w-4 rounded border accent-[#e8601a]"
+                    style={{ borderColor: "#e8e8e5" }}
+                  />
+                  On Major Release
+                </label>
+                <label className="flex items-center gap-2.5 text-[13px]" style={{ color: "#374151" }}>
+                  <input
+                    type="checkbox"
+                    checked={currentRules.on_minor_release ?? false}
+                    onChange={(e) =>
+                      setRulesDraft({ ...currentRules, on_minor_release: e.target.checked })
+                    }
+                    className="h-4 w-4 rounded border accent-[#e8601a]"
+                    style={{ borderColor: "#e8e8e5" }}
+                  />
+                  On Minor Release
+                </label>
+                <label className="flex items-center gap-2.5 text-[13px]" style={{ color: "#374151" }}>
+                  <input
+                    type="checkbox"
+                    checked={currentRules.on_security_patch ?? false}
+                    onChange={(e) =>
+                      setRulesDraft({ ...currentRules, on_security_patch: e.target.checked })
+                    }
+                    className="h-4 w-4 rounded border accent-[#e8601a]"
+                    style={{ borderColor: "#e8e8e5" }}
+                  />
+                  On Security Patch
+                </label>
+                <div className="mt-4">
+                  <label className="mb-1.5 block text-[13px]" style={{ color: "#374151" }}>
+                    Version Pattern
+                  </label>
+                  <input
+                    type="text"
+                    value={currentRules.version_pattern ?? ""}
+                    onChange={(e) =>
+                      setRulesDraft({ ...currentRules, version_pattern: e.target.value })
+                    }
+                    placeholder="e.g. ^v\\d+\\.\\d+\\.\\d+$"
+                    className="w-full max-w-md rounded-md border px-3 py-1.5 text-[13px] placeholder:text-[#9ca3af] focus:outline-none focus:ring-1"
+                    style={{
+                      fontFamily: "'JetBrains Mono', monospace",
+                      backgroundColor: "#fafaf9",
+                      borderColor: "#e8e8e5",
+                      color: "#111113",
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Run History section */}
+            <div>
+              <SectionLabel className="mb-3">Run History</SectionLabel>
+
+              {runsData?.data && runsData.data.length > 0 ? (
+                <div className="overflow-hidden rounded-md border" style={{ borderColor: "#e8e8e5" }}>
+                  <table className="w-full text-[13px]" style={{ fontFamily: "var(--font-dm-sans), sans-serif" }}>
+                    <thead>
+                      <tr style={{ backgroundColor: "#fafaf9" }}>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Trigger</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Status</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Started</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Duration</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Semantic Release</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {runsData.data.map((run) => (
+                        <tr key={run.id} className="border-t" style={{ borderColor: "#e8e8e5" }}>
+                          <td className="px-4 py-3" style={{ color: "#374151" }}>
+                            {run.trigger}
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <StatusDot status={run.status} />
+                              <span style={{ color: "#6b7280" }}>{run.status}</span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3" style={{ color: "#9ca3af" }}>
+                            {run.started_at
+                              ? new Date(run.started_at).toLocaleString()
+                              : "Pending"}
+                          </td>
+                          <td className="px-4 py-3" style={{ color: "#9ca3af" }}>
+                            {formatDuration(run.started_at, run.completed_at)}
+                          </td>
+                          <td className="px-4 py-3">
+                            {run.semantic_release_id ? (
+                              <Link
+                                href={`/projects/${id}/semantic-releases/${run.semantic_release_id}`}
+                                className="text-[13px] font-medium underline"
+                                style={{ color: "#e8601a" }}
+                              >
+                                View
+                              </Link>
+                            ) : (
+                              <span style={{ color: "#9ca3af" }}>--</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div
+                  className="flex h-32 items-center justify-center rounded-md border text-[13px]"
+                  style={{ borderColor: "#e8e8e5", color: "#9ca3af" }}
+                >
+                  No agent runs yet
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/components/projects/project-detail.tsx
+++ b/web/components/projects/project-detail.tsx
@@ -313,12 +313,12 @@ export function ProjectDetail({ id }: { id: string }) {
                 <table className="w-full text-[13px]" style={{ fontFamily: "var(--font-dm-sans), sans-serif" }}>
                   <thead>
                     <tr style={{ backgroundColor: "#fafaf9" }}>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Provider</th>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Repository</th>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Interval</th>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Status</th>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Last polled</th>
-                      <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}></th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Provider</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Repository</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Interval</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Status</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Last polled</th>
+                      <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -398,10 +398,10 @@ export function ProjectDetail({ id }: { id: string }) {
                 <table className="w-full text-[13px]" style={{ fontFamily: "var(--font-dm-sans), sans-serif" }}>
                   <thead>
                     <tr style={{ backgroundColor: "#fafaf9" }}>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Type</th>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Name</th>
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Config URL</th>
-                      <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}></th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Type</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Name</th>
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Config URL</th>
+                      <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -601,11 +601,11 @@ export function ProjectDetail({ id }: { id: string }) {
                   <table className="w-full text-[13px]" style={{ fontFamily: "var(--font-dm-sans), sans-serif" }}>
                     <thead>
                       <tr style={{ backgroundColor: "#fafaf9" }}>
-                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Trigger</th>
-                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Status</th>
-                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Started</th>
-                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Duration</th>
-                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider" style={{ color: "#9ca3af" }}>Semantic Release</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Trigger</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Status</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Started</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Duration</th>
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-[0.08em]" style={{ color: "#9ca3af" }}>Semantic Release</th>
                       </tr>
                     </thead>
                     <tbody>

--- a/web/components/releases/release-detail.tsx
+++ b/web/components/releases/release-detail.tsx
@@ -13,19 +13,7 @@ import { VersionChip } from "@/components/ui/version-chip";
 import type { SemanticRelease, Source, Project } from "@/lib/api/types";
 import { ArrowLeft } from "lucide-react";
 
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
-
-function timeAgo(dateStr?: string | null): string {
-  if (!dateStr) return "\u2014";
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+import { timeAgo } from "@/lib/format";
 
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
@@ -123,7 +111,7 @@ export function ReleaseDetail({ id }: { id: string }) {
             fontFamily: "var(--font-fraunces)",
             fontSize: "24px",
             fontWeight: 700,
-            color: "#1a1a1a",
+            color: "#111113",
           }}
         >
           Release {release.version}
@@ -180,7 +168,7 @@ export function ReleaseDetail({ id }: { id: string }) {
                 fontFamily: "var(--font-fraunces)",
                 fontSize: "16px",
                 fontWeight: 600,
-                color: "#1a1a1a",
+                color: "#111113",
               }}
             >
               Version Details
@@ -231,7 +219,7 @@ export function ReleaseDetail({ id }: { id: string }) {
                 fontFamily: "var(--font-fraunces)",
                 fontSize: "16px",
                 fontWeight: 600,
-                color: "#1a1a1a",
+                color: "#111113",
               }}
             >
               Semantic Releases
@@ -323,7 +311,7 @@ export function ReleaseDetail({ id }: { id: string }) {
                 fontFamily: "var(--font-fraunces)",
                 fontSize: "16px",
                 fontWeight: 600,
-                color: "#1a1a1a",
+                color: "#111113",
               }}
             >
               Raw Data

--- a/web/components/releases/release-detail.tsx
+++ b/web/components/releases/release-detail.tsx
@@ -2,75 +2,390 @@
 
 import useSWR from "swr";
 import Link from "next/link";
-import { releases as releasesApi } from "@/lib/api/client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import {
+  releases as releasesApi,
+  sources as sourcesApi,
+  semanticReleases as srApi,
+  projects as projectsApi,
+} from "@/lib/api/client";
+import { ProviderBadge } from "@/components/ui/provider-badge";
+import { VersionChip } from "@/components/ui/version-chip";
+import type { SemanticRelease, Source, Project } from "@/lib/api/types";
 import { ArrowLeft } from "lucide-react";
 
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function timeAgo(dateStr?: string | null): string {
+  if (!dateStr) return "\u2014";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
 export function ReleaseDetail({ id }: { id: string }) {
-  const { data: releaseData, isLoading } = useSWR(
-    `release-${id}`, () => releasesApi.get(id)
+  /* Fetch release */
+  const { data: releaseData, isLoading } = useSWR(`release-${id}`, () =>
+    releasesApi.get(id)
   );
 
-  if (isLoading) return <div className="py-12 text-center text-muted-foreground">Loading...</div>;
-
   const release = releaseData?.data;
-  if (!release) return <div className="py-12 text-center">Release not found</div>;
+
+  /* Fetch source info once we have the release */
+  const { data: sourceData } = useSWR(
+    release ? `source-${release.source_id}` : null,
+    () => (release ? sourcesApi.get(release.source_id) : null)
+  );
+  const source: Source | undefined = sourceData?.data;
+
+  /* Fetch project info once we have the source */
+  const { data: projectData } = useSWR(
+    source ? `project-${source.project_id}` : null,
+    () => (source ? projectsApi.get(source.project_id) : null)
+  );
+  const project: Project | undefined = projectData?.data;
+
+  /* Fetch linked semantic releases (via project) */
+  const { data: srData } = useSWR(
+    source ? `sr-for-release-${id}` : null,
+    async () => {
+      if (!source) return [];
+      const res = await srApi.list(source.project_id, 1).catch(() => null);
+      if (!res?.data) return [];
+      /* Filter semantic releases whose version matches this release version */
+      return res.data.filter((sr: SemanticRelease) => sr.version === release?.version);
+    }
+  );
+
+  const linkedSRs: SemanticRelease[] = srData ?? [];
+
+  /* Loading state */
+  if (isLoading) {
+    return (
+      <div
+        className="py-16 text-center"
+        style={{
+          fontFamily: "var(--font-dm-sans)",
+          fontSize: "13px",
+          color: "#6b7280",
+        }}
+      >
+        Loading...
+      </div>
+    );
+  }
+
+  if (!release) {
+    return (
+      <div className="py-16 text-center">
+        <p
+          style={{
+            fontFamily: "var(--font-fraunces)",
+            fontStyle: "italic",
+            fontSize: "15px",
+            color: "#9ca3af",
+          }}
+        >
+          Release not found
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div className="space-y-6">
-      <Link href="/releases">
-        <Button variant="ghost" size="sm">
-          <ArrowLeft className="mr-2 h-4 w-4" /> Back to Releases
-        </Button>
+    <div className="space-y-8">
+      {/* Back link */}
+      <Link
+        href="/releases"
+        className="inline-flex items-center gap-1.5 transition-colors hover:opacity-70"
+        style={{
+          fontFamily: "var(--font-dm-sans)",
+          fontSize: "13px",
+          color: "#6b7280",
+        }}
+      >
+        <ArrowLeft size={14} />
+        Back to Releases
       </Link>
 
-      {/* Release Header */}
+      {/* Header */}
       <div>
-        <h2 className="text-2xl font-bold font-mono">{release.version}</h2>
-        <div className="mt-1 flex items-center gap-2 text-muted-foreground">
-          <span className="text-sm">Source: {release.source_id}</span>
-          <span>&middot;</span>
-          <span>{new Date(release.created_at).toLocaleString()}</span>
+        <h1
+          style={{
+            fontFamily: "var(--font-fraunces)",
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#1a1a1a",
+          }}
+        >
+          Release {release.version}
+        </h1>
+        <div className="mt-2 flex items-center gap-3">
+          {source && <ProviderBadge provider={source.provider} />}
+          {source && (
+            <span
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: "12px",
+                color: "#374151",
+              }}
+            >
+              {source.repository}
+            </span>
+          )}
+          <VersionChip version={release.version} />
+        </div>
+        {project && (
+          <p
+            className="mt-2"
+            style={{
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "13px",
+              color: "#6b7280",
+            }}
+          >
+            Project:{" "}
+            <Link
+              href={`/projects/${project.id}`}
+              className="hover:underline"
+              style={{ color: "#e8601a" }}
+            >
+              {project.name}
+            </Link>
+          </p>
+        )}
+      </div>
+
+      {/* Info grid */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Version Details card */}
+        <div
+          className="rounded-lg bg-white"
+          style={{ border: "1px solid #e8e8e5" }}
+        >
+          <div
+            className="px-5 py-4"
+            style={{ borderBottom: "1px solid #e8e8e5" }}
+          >
+            <h2
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontSize: "16px",
+                fontWeight: 600,
+                color: "#1a1a1a",
+              }}
+            >
+              Version Details
+            </h2>
+          </div>
+          <div className="space-y-3 px-5 py-4">
+            <DetailRow label="Version" value={release.version} mono />
+            <DetailRow
+              label="Source ID"
+              value={release.source_id}
+              mono
+              small
+            />
+            {source && (
+              <>
+                <DetailRow label="Provider" value={source.provider} />
+                <DetailRow label="Repository" value={source.repository} mono />
+              </>
+            )}
+            {release.released_at && (
+              <DetailRow
+                label="Released At"
+                value={new Date(release.released_at).toLocaleString()}
+              />
+            )}
+            <DetailRow
+              label="Ingested At"
+              value={new Date(release.created_at).toLocaleString()}
+            />
+            <DetailRow
+              label="Age"
+              value={timeAgo(release.released_at ?? release.created_at)}
+            />
+          </div>
+        </div>
+
+        {/* Linked Semantic Releases */}
+        <div
+          className="rounded-lg bg-white"
+          style={{ border: "1px solid #e8e8e5" }}
+        >
+          <div
+            className="px-5 py-4"
+            style={{ borderBottom: "1px solid #e8e8e5" }}
+          >
+            <h2
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontSize: "16px",
+                fontWeight: 600,
+                color: "#1a1a1a",
+              }}
+            >
+              Semantic Releases
+            </h2>
+          </div>
+          <div className="px-5 py-4">
+            {linkedSRs.length > 0 ? (
+              <div className="space-y-3">
+                {linkedSRs.map((sr) => (
+                  <Link
+                    key={sr.id}
+                    href={`/projects/${sr.project_id}/semantic-releases/${sr.id}`}
+                    className="block rounded-lg px-4 py-3 transition-colors hover:bg-[#fafaf9]"
+                    style={{ border: "1px solid #e8e8e5" }}
+                  >
+                    <div className="flex items-center justify-between">
+                      <VersionChip version={sr.version} />
+                      <span
+                        className="rounded-full px-2 py-0.5"
+                        style={{
+                          fontFamily: "var(--font-dm-sans)",
+                          fontSize: "11px",
+                          fontWeight: 500,
+                          color:
+                            sr.status === "completed" ? "#16a34a" : "#e8601a",
+                          backgroundColor:
+                            sr.status === "completed" ? "#f0fdf4" : "#fff7ed",
+                        }}
+                      >
+                        {sr.status}
+                      </span>
+                    </div>
+                    {sr.report?.summary && (
+                      <p
+                        className="mt-2 line-clamp-2"
+                        style={{
+                          fontFamily: "var(--font-dm-sans)",
+                          fontStyle: "italic",
+                          fontSize: "13px",
+                          color: "#6b7280",
+                        }}
+                      >
+                        {sr.report.summary}
+                      </p>
+                    )}
+                    <p
+                      className="mt-1"
+                      style={{
+                        fontFamily: "var(--font-dm-sans)",
+                        fontSize: "12px",
+                        color: "#9ca3af",
+                      }}
+                    >
+                      {timeAgo(sr.created_at)}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <div className="py-6 text-center">
+                <p
+                  style={{
+                    fontFamily: "var(--font-fraunces)",
+                    fontStyle: "italic",
+                    fontSize: "14px",
+                    color: "#9ca3af",
+                  }}
+                >
+                  No semantic releases linked
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Card>
-          <CardHeader><CardTitle className="text-base">Version Details</CardTitle></CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">Version</span>
-              <span className="font-mono">{release.version}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">Source ID</span>
-              <span className="font-mono text-xs">{release.source_id}</span>
-            </div>
-            {release.released_at && (
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Released At</span>
-                <span>{new Date(release.released_at).toLocaleString()}</span>
-              </div>
-            )}
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">Ingested At</span>
-              <span>{new Date(release.created_at).toLocaleString()}</span>
-            </div>
-          </CardContent>
-        </Card>
+      {/* Raw data */}
+      {release.raw_data && Object.keys(release.raw_data).length > 0 && (
+        <div
+          className="rounded-lg bg-white"
+          style={{ border: "1px solid #e8e8e5" }}
+        >
+          <div
+            className="px-5 py-4"
+            style={{ borderBottom: "1px solid #e8e8e5" }}
+          >
+            <h2
+              style={{
+                fontFamily: "var(--font-fraunces)",
+                fontSize: "16px",
+                fontWeight: 600,
+                color: "#1a1a1a",
+              }}
+            >
+              Raw Data
+            </h2>
+          </div>
+          <div className="p-5">
+            <pre
+              className="overflow-x-auto rounded-lg p-4"
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: "12px",
+                lineHeight: 1.6,
+                color: "#374151",
+                backgroundColor: "#fafaf9",
+                border: "1px solid #e8e8e5",
+              }}
+            >
+              {JSON.stringify(release.raw_data, null, 2)}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
-        {release.raw_data && Object.keys(release.raw_data).length > 0 && (
-          <Card>
-            <CardHeader><CardTitle className="text-base">Raw Data</CardTitle></CardHeader>
-            <CardContent>
-              <pre className="rounded bg-muted p-3 text-xs overflow-x-auto whitespace-pre-wrap">
-                {JSON.stringify(release.raw_data, null, 2)}
-              </pre>
-            </CardContent>
-          </Card>
-        )}
-      </div>
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+function DetailRow({
+  label,
+  value,
+  mono,
+  small,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  small?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span
+        style={{
+          fontFamily: "var(--font-dm-sans)",
+          fontSize: "13px",
+          color: "#9ca3af",
+        }}
+      >
+        {label}
+      </span>
+      <span
+        className="text-right"
+        style={{
+          fontFamily: mono ? "'JetBrains Mono', monospace" : "var(--font-dm-sans)",
+          fontSize: small ? "11px" : "13px",
+          color: "#374151",
+        }}
+      >
+        {value}
+      </span>
     </div>
   );
 }

--- a/web/components/semantic-releases/semantic-release-detail.tsx
+++ b/web/components/semantic-releases/semantic-release-detail.tsx
@@ -8,16 +8,7 @@ import { VersionChip } from "@/components/ui/version-chip";
 import { SectionLabel } from "@/components/ui/section-label";
 import { UrgencyCallout } from "@/components/ui/urgency-callout";
 import { ProviderBadge } from "@/components/ui/provider-badge";
-
-function timeAgo(dateStr?: string | null): string {
-  if (!dateStr) return "\u2014";
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+import { timeAgo } from "@/lib/format";
 
 export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; srId: string }) {
   const { data, isLoading } = useSWR(`sr-${srId}`, () => srApi.get(srId));
@@ -28,7 +19,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
   if (isLoading) {
     return (
       <div className="flex justify-center py-20">
-        <div className="text-[13px] text-[#9ca3af]" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+        <div className="text-[13px] text-[#9ca3af]" style={{ fontFamily: "var(--font-dm-sans)" }}>
           Loading...
         </div>
       </div>
@@ -39,7 +30,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
   if (!sr) {
     return (
       <div className="flex justify-center py-20">
-        <div className="text-[13px] text-[#9ca3af]" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+        <div className="text-[13px] text-[#9ca3af]" style={{ fontFamily: "var(--font-dm-sans)" }}>
           Semantic release not found
         </div>
       </div>
@@ -56,7 +47,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
       {/* 1. Breadcrumb */}
       <nav
         className="mb-6 flex items-center gap-1.5 text-[12px] text-[#9ca3af]"
-        style={{ fontFamily: "'DM Sans', sans-serif" }}
+        style={{ fontFamily: "var(--font-dm-sans)" }}
       >
         <Link href="/projects" className="hover:text-[#111113] transition-colors">
           Projects
@@ -75,7 +66,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
       {project?.name && (
         <p
           className="mb-1 text-[13px] italic text-[#9ca3af]"
-          style={{ fontFamily: "'Fraunces', serif" }}
+          style={{ fontFamily: "var(--font-fraunces)" }}
         >
           {project.name}
         </p>
@@ -84,7 +75,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
       {/* 3. Version heading */}
       <h1
         className="text-[42px] font-bold tracking-tight text-[#111113] leading-[1.1]"
-        style={{ fontFamily: "'Fraunces', serif" }}
+        style={{ fontFamily: "var(--font-fraunces)" }}
       >
         {sr.version}
       </h1>
@@ -92,7 +83,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
       {/* 4. Meta line */}
       <div
         className="mt-3 flex items-center gap-2 text-[13px] text-[#6b7280]"
-        style={{ fontFamily: "'DM Sans', sans-serif" }}
+        style={{ fontFamily: "var(--font-dm-sans)" }}
       >
         <StatusDot status={sr.status} />
         <span>
@@ -111,7 +102,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
           style={{
             border: "1px solid #fca5a5",
             backgroundColor: "#fef2f2",
-            fontFamily: "'DM Sans', sans-serif",
+            fontFamily: "var(--font-dm-sans)",
           }}
         >
           {sr.error}
@@ -125,7 +116,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
             <SectionLabel className="mb-3">Summary</SectionLabel>
             <p
               className="text-[16px] leading-[1.7] text-[#111113]"
-              style={{ fontFamily: "'DM Sans', sans-serif" }}
+              style={{ fontFamily: "var(--font-dm-sans)" }}
             >
               {sr.report.summary}
             </p>
@@ -143,7 +134,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
               <SectionLabel className="mb-2">Availability</SectionLabel>
               <p
                 className="text-[14px] leading-[1.6] text-[#111113]"
-                style={{ fontFamily: "'DM Sans', sans-serif" }}
+                style={{ fontFamily: "var(--font-dm-sans)" }}
               >
                 {sr.report.availability}
               </p>
@@ -155,7 +146,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
               <SectionLabel className="mb-2">Adoption</SectionLabel>
               <p
                 className="text-[14px] leading-[1.6] text-[#111113]"
-                style={{ fontFamily: "'DM Sans', sans-serif" }}
+                style={{ fontFamily: "var(--font-dm-sans)" }}
               >
                 {sr.report.adoption}
               </p>
@@ -167,7 +158,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
             <blockquote
               className="rounded-md px-5 py-4 text-[18px] italic leading-[1.6] text-[#16181c]"
               style={{
-                fontFamily: "'Fraunces', serif",
+                fontFamily: "var(--font-fraunces)",
                 borderLeft: "3px solid #e8601a",
                 backgroundColor: "#fafaf9",
               }}
@@ -190,26 +181,26 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
               <thead>
                 <tr style={{ backgroundColor: "#fafaf9", borderBottom: "1px solid #e8e8e5" }}>
                   <th
-                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
-                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.08em] text-[#9ca3af]"
+                    style={{ fontFamily: "var(--font-dm-sans)" }}
                   >
                     Provider
                   </th>
                   <th
-                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
-                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.08em] text-[#9ca3af]"
+                    style={{ fontFamily: "var(--font-dm-sans)" }}
                   >
                     Repository
                   </th>
                   <th
-                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
-                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.08em] text-[#9ca3af]"
+                    style={{ fontFamily: "var(--font-dm-sans)" }}
                   >
                     Version
                   </th>
                   <th
-                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
-                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.08em] text-[#9ca3af]"
+                    style={{ fontFamily: "var(--font-dm-sans)" }}
                   >
                     Date
                   </th>
@@ -245,7 +236,7 @@ export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; 
                       <td className="px-4 py-3">
                         <span
                           className="text-[13px] text-[#6b7280]"
-                          style={{ fontFamily: "'DM Sans', sans-serif" }}
+                          style={{ fontFamily: "var(--font-dm-sans)" }}
                         >
                           {timeAgo(rel.released_at ?? rel.created_at)}
                         </span>

--- a/web/components/semantic-releases/semantic-release-detail.tsx
+++ b/web/components/semantic-releases/semantic-release-detail.tsx
@@ -2,90 +2,261 @@
 
 import useSWR from "swr";
 import Link from "next/link";
-import { semanticReleases as srApi } from "@/lib/api/client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
+import { semanticReleases as srApi, projects as projectsApi, releases as releasesApi, sources as sourcesApi } from "@/lib/api/client";
+import { StatusDot } from "@/components/ui/status-dot";
+import { VersionChip } from "@/components/ui/version-chip";
+import { SectionLabel } from "@/components/ui/section-label";
+import { UrgencyCallout } from "@/components/ui/urgency-callout";
+import { ProviderBadge } from "@/components/ui/provider-badge";
 
-const statusColors: Record<string, string> = {
-  completed: "bg-green-100 text-green-800",
-  running: "bg-blue-100 text-blue-800",
-  pending: "bg-gray-100 text-gray-800",
-  failed: "bg-red-100 text-red-800",
-};
+function timeAgo(dateStr?: string | null): string {
+  if (!dateStr) return "\u2014";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
 
 export function SemanticReleaseDetail({ projectId, srId }: { projectId: string; srId: string }) {
   const { data, isLoading } = useSWR(`sr-${srId}`, () => srApi.get(srId));
+  const { data: projectData } = useSWR(`project-${projectId}`, () => projectsApi.get(projectId));
+  const { data: releasesData } = useSWR(`project-releases-${projectId}`, () => releasesApi.listByProject(projectId));
+  const { data: sourcesData } = useSWR(`project-sources-${projectId}`, () => sourcesApi.listByProject(projectId));
 
-  if (isLoading) return <div className="py-12 text-center text-muted-foreground">Loading...</div>;
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-20">
+        <div className="text-[13px] text-[#9ca3af]" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+          Loading...
+        </div>
+      </div>
+    );
+  }
 
   const sr = data?.data;
-  if (!sr) return <div className="py-12 text-center">Semantic release not found</div>;
+  if (!sr) {
+    return (
+      <div className="flex justify-center py-20">
+        <div className="text-[13px] text-[#9ca3af]" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+          Semantic release not found
+        </div>
+      </div>
+    );
+  }
+
+  const project = projectData?.data;
+  const releasesList = releasesData?.data ?? [];
+  const sourcesList = sourcesData?.data ?? [];
+  const sourcesById = Object.fromEntries(sourcesList.map((s) => [s.id, s]));
 
   return (
-    <div className="space-y-6">
-      <Link href={`/projects/${projectId}/semantic-releases`}>
-        <Button variant="ghost" size="sm">
-          <ArrowLeft className="mr-2 h-4 w-4" /> Back to Semantic Releases
-        </Button>
-      </Link>
+    <div className="fade-in mx-auto max-w-[760px]">
+      {/* 1. Breadcrumb */}
+      <nav
+        className="mb-6 flex items-center gap-1.5 text-[12px] text-[#9ca3af]"
+        style={{ fontFamily: "'DM Sans', sans-serif" }}
+      >
+        <Link href="/projects" className="hover:text-[#111113] transition-colors">
+          Projects
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}`} className="hover:text-[#111113] transition-colors">
+          {project?.name ?? projectId}
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}/semantic-releases`} className="hover:text-[#111113] transition-colors">
+          Semantic Releases
+        </Link>
+      </nav>
 
-      <div className="flex items-center gap-3">
-        <h2 className="text-2xl font-bold font-mono">{sr.version}</h2>
-        <Badge className={statusColors[sr.status] ?? ""}>{sr.status}</Badge>
+      {/* 2. Byline */}
+      {project?.name && (
+        <p
+          className="mb-1 text-[13px] italic text-[#9ca3af]"
+          style={{ fontFamily: "'Fraunces', serif" }}
+        >
+          {project.name}
+        </p>
+      )}
+
+      {/* 3. Version heading */}
+      <h1
+        className="text-[42px] font-bold tracking-tight text-[#111113] leading-[1.1]"
+        style={{ fontFamily: "'Fraunces', serif" }}
+      >
+        {sr.version}
+      </h1>
+
+      {/* 4. Meta line */}
+      <div
+        className="mt-3 flex items-center gap-2 text-[13px] text-[#6b7280]"
+        style={{ fontFamily: "'DM Sans', sans-serif" }}
+      >
+        <StatusDot status={sr.status} />
+        <span>
+          {sr.status}
+          {sr.completed_at && ` \u00b7 generated ${timeAgo(sr.completed_at)}`}
+        </span>
       </div>
 
-      <div className="flex gap-4 text-sm text-muted-foreground">
-        <span>Created: {new Date(sr.created_at).toLocaleString()}</span>
-        {sr.completed_at && <span>Completed: {new Date(sr.completed_at).toLocaleString()}</span>}
-      </div>
+      {/* 5. Divider */}
+      <hr className="my-8 border-0" style={{ borderTop: "1px solid #e8e8e5" }} />
 
+      {/* 6. Error state */}
       {sr.error && (
-        <Card className="border-red-200">
-          <CardContent className="p-4">
-            <div className="text-sm text-red-700">{sr.error}</div>
-          </CardContent>
-        </Card>
+        <div
+          className="mb-8 rounded-md px-4 py-3 text-[14px] text-[#991b1b]"
+          style={{
+            border: "1px solid #fca5a5",
+            backgroundColor: "#fef2f2",
+            fontFamily: "'DM Sans', sans-serif",
+          }}
+        >
+          {sr.error}
+        </div>
       )}
 
       {sr.report && (
-        <div className="grid gap-6 lg:grid-cols-2">
-          <Card className="lg:col-span-2">
-            <CardHeader><CardTitle className="text-base">Summary</CardTitle></CardHeader>
-            <CardContent>
-              <p className="text-sm leading-relaxed">{sr.report.summary}</p>
-            </CardContent>
-          </Card>
+        <div className="space-y-10">
+          {/* 7. Summary section */}
+          <section>
+            <SectionLabel className="mb-3">Summary</SectionLabel>
+            <p
+              className="text-[16px] leading-[1.7] text-[#111113]"
+              style={{ fontFamily: "'DM Sans', sans-serif" }}
+            >
+              {sr.report.summary}
+            </p>
+          </section>
 
-          <Card>
-            <CardHeader><CardTitle className="text-base">Availability</CardTitle></CardHeader>
-            <CardContent>
-              <p className="text-sm leading-relaxed">{sr.report.availability}</p>
-            </CardContent>
-          </Card>
+          {/* 8. Urgency callout */}
+          <UrgencyCallout urgency={sr.report.urgency} />
 
-          <Card>
-            <CardHeader><CardTitle className="text-base">Adoption</CardTitle></CardHeader>
-            <CardContent>
-              <p className="text-sm leading-relaxed">{sr.report.adoption}</p>
-            </CardContent>
-          </Card>
+          {/* 9. Availability + Adoption cards */}
+          <div className="grid grid-cols-2 gap-4">
+            <div
+              className="rounded-md p-5"
+              style={{ border: "1px solid #e8e8e5", backgroundColor: "#ffffff" }}
+            >
+              <SectionLabel className="mb-2">Availability</SectionLabel>
+              <p
+                className="text-[14px] leading-[1.6] text-[#111113]"
+                style={{ fontFamily: "'DM Sans', sans-serif" }}
+              >
+                {sr.report.availability}
+              </p>
+            </div>
+            <div
+              className="rounded-md p-5"
+              style={{ border: "1px solid #e8e8e5", backgroundColor: "#ffffff" }}
+            >
+              <SectionLabel className="mb-2">Adoption</SectionLabel>
+              <p
+                className="text-[14px] leading-[1.6] text-[#111113]"
+                style={{ fontFamily: "'DM Sans', sans-serif" }}
+              >
+                {sr.report.adoption}
+              </p>
+            </div>
+          </div>
 
-          <Card>
-            <CardHeader><CardTitle className="text-base">Urgency</CardTitle></CardHeader>
-            <CardContent>
-              <p className="text-sm leading-relaxed">{sr.report.urgency}</p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader><CardTitle className="text-base">Recommendation</CardTitle></CardHeader>
-            <CardContent>
-              <p className="text-sm leading-relaxed">{sr.report.recommendation}</p>
-            </CardContent>
-          </Card>
+          {/* 10. Recommendation pull-quote */}
+          {sr.report.recommendation && (
+            <blockquote
+              className="rounded-md px-5 py-4 text-[18px] italic leading-[1.6] text-[#16181c]"
+              style={{
+                fontFamily: "'Fraunces', serif",
+                borderLeft: "3px solid #e8601a",
+                backgroundColor: "#fafaf9",
+              }}
+            >
+              {sr.report.recommendation}
+            </blockquote>
+          )}
         </div>
+      )}
+
+      {/* 11. Source Releases section */}
+      {releasesList.length > 0 && (
+        <section className="mt-10">
+          <SectionLabel className="mb-4">Source Releases</SectionLabel>
+          <div
+            className="overflow-hidden rounded-md"
+            style={{ border: "1px solid #e8e8e5" }}
+          >
+            <table className="w-full text-left">
+              <thead>
+                <tr style={{ backgroundColor: "#fafaf9", borderBottom: "1px solid #e8e8e5" }}>
+                  <th
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
+                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                  >
+                    Provider
+                  </th>
+                  <th
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
+                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                  >
+                    Repository
+                  </th>
+                  <th
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
+                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                  >
+                    Version
+                  </th>
+                  <th
+                    className="px-4 py-2.5 text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]"
+                    style={{ fontFamily: "'DM Sans', sans-serif" }}
+                  >
+                    Date
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {releasesList.map((rel) => {
+                  const source = sourcesById[rel.source_id];
+                  return (
+                    <tr
+                      key={rel.id}
+                      style={{ borderBottom: "1px solid #e8e8e5" }}
+                      className="last:border-b-0"
+                    >
+                      <td className="px-4 py-3">
+                        {source ? (
+                          <ProviderBadge provider={source.provider} />
+                        ) : (
+                          <span className="text-[12px] text-[#9ca3af]">{"\u2014"}</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className="text-[13px] text-[#374151]"
+                          style={{ fontFamily: "'JetBrains Mono', monospace" }}
+                        >
+                          {source?.repository ?? "\u2014"}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <VersionChip version={rel.version} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className="text-[13px] text-[#6b7280]"
+                          style={{ fontFamily: "'DM Sans', sans-serif" }}
+                        >
+                          {timeAgo(rel.released_at ?? rel.created_at)}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
       )}
     </div>
   );

--- a/web/components/ui/provider-badge.tsx
+++ b/web/components/ui/provider-badge.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+const PROVIDER_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  github: { bg: "#1a1a1a", text: "#ffffff", label: "GitHub" },
+  dockerhub: { bg: "#2496ed", text: "#ffffff", label: "Docker Hub" },
+};
+
+interface ProviderBadgeProps {
+  provider: string;
+  className?: string;
+}
+
+export function ProviderBadge({ provider, className }: ProviderBadgeProps) {
+  const style = PROVIDER_STYLES[provider.toLowerCase()] ?? {
+    bg: "#6b7280",
+    text: "#ffffff",
+    label: provider,
+  };
+  return (
+    <span
+      className={cn("inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium leading-none", className)}
+      style={{ backgroundColor: style.bg, color: style.text }}
+    >
+      {style.label}
+    </span>
+  );
+}

--- a/web/components/ui/section-label.tsx
+++ b/web/components/ui/section-label.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+
+interface SectionLabelProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SectionLabel({ children, className }: SectionLabelProps) {
+  return (
+    <p
+      className={cn("text-[11px] font-medium uppercase tracking-[0.12em] text-[#9ca3af]", className)}
+    >
+      {children}
+    </p>
+  );
+}

--- a/web/components/ui/status-dot.tsx
+++ b/web/components/ui/status-dot.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+const STATUS_COLORS: Record<string, string> = {
+  completed: "#16a34a",
+  running: "#2563eb",
+  pending: "#d97706",
+  failed: "#dc2626",
+};
+
+interface StatusDotProps {
+  status: string;
+  className?: string;
+}
+
+export function StatusDot({ status, className }: StatusDotProps) {
+  const color = STATUS_COLORS[status.toLowerCase()] ?? "#6b7280";
+  return (
+    <span
+      className={cn("inline-block h-2 w-2 rounded-full shrink-0", className)}
+      style={{ backgroundColor: color }}
+      title={status}
+    />
+  );
+}

--- a/web/components/ui/urgency-callout.tsx
+++ b/web/components/ui/urgency-callout.tsx
@@ -1,0 +1,37 @@
+import { AlertTriangle, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface UrgencyCalloutProps {
+  urgency: string;
+  description?: string;
+  className?: string;
+}
+
+export function UrgencyCallout({ urgency, description, className }: UrgencyCalloutProps) {
+  const upper = urgency?.toUpperCase();
+  if (upper !== "HIGH" && upper !== "CRITICAL") return null;
+
+  const isCritical = upper === "CRITICAL";
+  const bg = isCritical ? "#fff1f2" : "#fff8f0";
+  const border = isCritical ? "#dc2626" : "#d97706";
+  const Icon = isCritical ? AlertCircle : AlertTriangle;
+
+  return (
+    <div
+      className={cn("rounded px-4 py-3 text-sm", className)}
+      style={{ backgroundColor: bg, borderLeft: `3px solid ${border}` }}
+    >
+      <div className="flex items-start gap-2">
+        <Icon className="h-4 w-4 mt-0.5 shrink-0" style={{ color: border }} />
+        <div>
+          <span className="font-semibold" style={{ color: border }}>
+            {upper} URGENCY
+          </span>
+          {description && (
+            <p className="mt-0.5 text-[#374151]">{description}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/ui/version-chip.tsx
+++ b/web/components/ui/version-chip.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+
+interface VersionChipProps {
+  version: string;
+  className?: string;
+}
+
+export function VersionChip({ version, className }: VersionChipProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[12px] leading-none text-[#374151]",
+        className
+      )}
+      style={{ backgroundColor: "#f3f3f1", fontFamily: "'JetBrains Mono', monospace" }}
+    >
+      {version}
+    </span>
+  );
+}

--- a/web/lib/format.ts
+++ b/web/lib/format.ts
@@ -1,0 +1,9 @@
+export function timeAgo(dateStr?: string | null): string {
+  if (!dateStr) return "\u2014";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "export",
+  output: process.env.NODE_ENV === "production" ? "export" : undefined,
 };
 
 export default nextConfig;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -925,6 +926,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",


### PR DESCRIPTION
## Summary

- **Complete visual redesign** of the ReleaseBeacon frontend from shadcn defaults to a distinctive editorial / data-journalism aesthetic
- Dark charcoal sidebar (`#16181c`) + warm white content area (`#fafaf9`) with orange accent (`#e8601a`)
- Three-font typography: **Fraunces** (display serif), **DM Sans** (body), **JetBrains Mono** (monospace)
- 5 shared micro-components: `ProviderBadge`, `StatusDot`, `VersionChip`, `SectionLabel`, `UrgencyCallout`
- All 7 main pages redesigned: Dashboard, Projects, Project Detail (4-tab layout), Releases, Release Detail, Channels, Subscriptions
- Semantic release detail as editorial centerpiece (single-column, max-width 760px)
- Code review fixes: normalized color tokens, extracted shared `timeAgo` utility, fixed font references
- Dev-mode fix: conditional `output: "export"` so dynamic routes work in `next dev`

## Changes (23 files, +2624 / -892)

| Area | What changed |
|------|-------------|
| `globals.css` | Hex design tokens replacing oklch, status colors, fade-in animation |
| `layout.tsx` | Fraunces + DM Sans via `next/font/google`, removed Geist |
| `next.config.ts` | Conditional `output: "export"` (production only) |
| Sidebar | Dark bg, 200px fixed, 5 nav items, 3px orange active border |
| Header | 48px, white, URL-based breadcrumb |
| Dashboard | 4-card stat strip + two-column (releases table / semantic releases cards) |
| Projects list | Matching editorial table style |
| Project detail | Header zone + 4 tabs (Sources, Context Sources, Semantic Releases, Agent) |
| Semantic release detail | Editorial single-column layout, pull-quote, urgency callout |
| Releases | Full-width table with project filter, pagination |
| Channels | CRUD table with per-type colored badges (Slack/Discord/Webhook) |
| Subscriptions | CRUD table with type badges, channel name resolution |
| `lib/format.ts` | Shared `timeAgo` utility (extracted from 5 files) |
| `components/ui/` | 5 new micro-components |

## Test plan

- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [x] Production build succeeds (`npm run build`, all 25 routes generated)
- [x] Visual testing via Playwright: Dashboard, Projects, Project Detail, Releases, Channels, Subscriptions
- [ ] Manual review of populated data states (with real releases/sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)