### PR TITLE
fix: use GHCR image timestamps

### DIFF
--- a/internal/ingestion/ghcr.go
+++ b/internal/ingestion/ghcr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,6 +12,8 @@ import (
 )
 
 const defaultGHCRURL = "https://ghcr.io"
+
+const ghcrManifestAccept = "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json"
 
 // GHCRSource polls GitHub Container Registry for image tags.
 type GHCRSource struct {
@@ -51,19 +54,18 @@ func (s *GHCRSource) FetchNewReleases(ctx context.Context) ([]IngestionResult, e
 		last = nextLast
 	}
 
-	now := time.Now()
 	results := make([]IngestionResult, 0, len(allTags))
 	for _, tag := range allTags {
 		if tag == "" {
 			continue
 		}
+		ts, metadata := s.fetchTagMetadata(ctx, tag)
+		metadata["release_url"] = fmt.Sprintf("https://ghcr.io/%s:%s", s.repository, url.PathEscape(tag))
 		results = append(results, IngestionResult{
 			Repository: s.repository,
 			RawVersion: tag,
-			Metadata: map[string]string{
-				"release_url": fmt.Sprintf("https://ghcr.io/%s:%s", s.repository, url.PathEscape(tag)),
-			},
-			Timestamp: now,
+			Metadata:   metadata,
+			Timestamp:  ts,
 		})
 	}
 	return results, nil
@@ -112,6 +114,152 @@ func (s *GHCRSource) fetchTagsPage(ctx context.Context, last string) (ghcrTagsRe
 		return ghcrTagsResponse{}, "", fmt.Errorf("decode response: %w", err)
 	}
 	return body, parseRegistryNextLast(resp.Header.Get("Link")), nil
+}
+
+func (s *GHCRSource) fetchTagMetadata(ctx context.Context, tag string) (time.Time, map[string]string) {
+	metadata := map[string]string{}
+	manifest, err := s.fetchManifest(ctx, tag)
+	if err != nil {
+		metadata["timestamp_source"] = "unavailable"
+		metadata["timestamp_error"] = err.Error()
+		return time.Time{}, metadata
+	}
+
+	if ts, ok := timestampFromAnnotations(manifest.Annotations); ok {
+		metadata["timestamp_source"] = "manifest_annotation"
+		return ts, metadata
+	}
+
+	if manifest.Config != nil && manifest.Config.Digest != "" {
+		if config, err := s.fetchConfig(ctx, manifest.Config.Digest); err == nil {
+			if ts, ok := timestampFromConfig(config); ok {
+				metadata["timestamp_source"] = "image_config"
+				return ts, metadata
+			}
+		} else {
+			metadata["timestamp_error"] = err.Error()
+		}
+	}
+
+	var latest time.Time
+	for _, child := range manifest.Manifests {
+		if ts, ok := timestampFromAnnotations(child.Annotations); ok && ts.After(latest) {
+			latest = ts
+		}
+	}
+	if !latest.IsZero() {
+		metadata["timestamp_source"] = "manifest_list_annotation"
+		return latest, metadata
+	}
+
+	metadata["timestamp_source"] = "unavailable"
+	return time.Time{}, metadata
+}
+
+type ghcrManifest struct {
+	Config *struct {
+		Digest string `json:"digest"`
+	} `json:"config"`
+	Manifests []struct {
+		Annotations map[string]string `json:"annotations"`
+	} `json:"manifests"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+type ghcrConfig struct {
+	Created string `json:"created"`
+	Config  struct {
+		Labels map[string]string `json:"Labels"`
+	} `json:"config"`
+	History []struct {
+		Created string `json:"created"`
+	} `json:"history"`
+}
+
+func (s *GHCRSource) fetchManifest(ctx context.Context, reference string) (ghcrManifest, error) {
+	resp, err := s.doRegistryRequest(ctx, func(token string) (*http.Request, error) {
+		u := strings.TrimRight(s.baseURL, "/") + "/v2/" + s.repository + "/manifests/" + url.PathEscape(reference)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create manifest request: %w", err)
+		}
+		req.Header.Set("Accept", ghcrManifestAccept)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		return req, nil
+	})
+	if err != nil {
+		return ghcrManifest{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ghcrManifest{}, httpStatusError(resp)
+	}
+	var manifest ghcrManifest
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return ghcrManifest{}, fmt.Errorf("decode manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func (s *GHCRSource) fetchConfig(ctx context.Context, digest string) (ghcrConfig, error) {
+	resp, err := s.doRegistryRequest(ctx, func(token string) (*http.Request, error) {
+		u := strings.TrimRight(s.baseURL, "/") + "/v2/" + s.repository + "/blobs/" + digest
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create config request: %w", err)
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		return req, nil
+	})
+	if err != nil {
+		return ghcrConfig{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ghcrConfig{}, httpStatusError(resp)
+	}
+	var config ghcrConfig
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return ghcrConfig{}, fmt.Errorf("decode config: %w", err)
+	}
+	return config, nil
+}
+
+func (s *GHCRSource) doRegistryRequest(ctx context.Context, newRequest func(token string) (*http.Request, error)) (*http.Response, error) {
+	resp, err := doRequestWithToken(newRequest, "", s.client)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+
+	challenge := resp.Header.Get("WWW-Authenticate")
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	token, err := s.fetchBearerToken(ctx, challenge)
+	if err != nil {
+		return nil, err
+	}
+	return doRequestWithToken(newRequest, token, s.client)
+}
+
+func doRequestWithToken(newRequest func(token string) (*http.Request, error), token string, client *http.Client) (*http.Response, error) {
+	req, err := newRequest(token)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("registry request: %w", err)
+	}
+	return resp, nil
 }
 
 func (s *GHCRSource) newTagsRequest(ctx context.Context, last string, token string) (*http.Request, error) {
@@ -192,6 +340,52 @@ func validateGHCRRepository(repository string) error {
 		return fmt.Errorf("ghcr repository must be owner/image, got %q", repository)
 	}
 	return nil
+}
+
+func timestampFromAnnotations(annotations map[string]string) (time.Time, bool) {
+	for _, key := range []string{
+		"org.opencontainers.image.created",
+		"org.label-schema.build-date",
+		"org.label-schema.created",
+		"build-date",
+	} {
+		if ts, ok := parseGHCROCIUTCTime(annotations[key]); ok {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func timestampFromConfig(config ghcrConfig) (time.Time, bool) {
+	if ts, ok := parseGHCROCIUTCTime(config.Created); ok {
+		return ts, true
+	}
+	if ts, ok := timestampFromAnnotations(config.Config.Labels); ok {
+		return ts, true
+	}
+	var latest time.Time
+	for _, h := range config.History {
+		if ts, ok := parseGHCROCIUTCTime(h.Created); ok && ts.After(latest) {
+			latest = ts
+		}
+	}
+	if !latest.IsZero() {
+		return latest, true
+	}
+	return time.Time{}, false
+}
+
+func parseGHCROCIUTCTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if ts, err := time.Parse(layout, value); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func parseBearerChallenge(challenge string) (realm, service, scope string) {

--- a/internal/ingestion/ghcr_test.go
+++ b/internal/ingestion/ghcr_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGHCRSourceName(t *testing.T) {
@@ -17,14 +18,25 @@ func TestGHCRSourceName(t *testing.T) {
 
 func TestGHCRFetchNewReleases(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/sentioxyz/changelogue/tags/list" {
+		switch r.URL.Path {
+		case "/v2/sentioxyz/changelogue/tags/list":
+			if got := r.URL.Query().Get("n"); got != "100" {
+				t.Fatalf("n = %q, want 100", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["v1.0.0","latest"]}`))
+		case "/v2/sentioxyz/changelogue/manifests/v1.0.0":
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			_, _ = w.Write([]byte(`{"annotations":{"org.opencontainers.image.created":"2026-01-02T03:04:05Z"}}`))
+		case "/v2/sentioxyz/changelogue/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			_, _ = w.Write([]byte(`{"config":{"digest":"sha256:latest-config"}}`))
+		case "/v2/sentioxyz/changelogue/blobs/sha256:latest-config":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"created":"2026-01-03T04:05:06Z"}`))
+		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("n"); got != "100" {
-			t.Fatalf("n = %q, want 100", got)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["v1.0.0","latest"]}`))
 	}))
 	defer srv.Close()
 
@@ -47,6 +59,20 @@ func TestGHCRFetchNewReleases(t *testing.T) {
 	if got := results[0].Metadata["release_url"]; got != "https://ghcr.io/sentioxyz/changelogue:v1.0.0" {
 		t.Errorf("release_url = %q", got)
 	}
+	expected, _ := time.Parse(time.RFC3339, "2026-01-02T03:04:05Z")
+	if !results[0].Timestamp.Equal(expected) {
+		t.Errorf("results[0].Timestamp = %v, want %v", results[0].Timestamp, expected)
+	}
+	if got := results[0].Metadata["timestamp_source"]; got != "manifest_annotation" {
+		t.Errorf("timestamp_source = %q, want manifest_annotation", got)
+	}
+	expectedConfig, _ := time.Parse(time.RFC3339, "2026-01-03T04:05:06Z")
+	if !results[1].Timestamp.Equal(expectedConfig) {
+		t.Errorf("results[1].Timestamp = %v, want %v", results[1].Timestamp, expectedConfig)
+	}
+	if got := results[1].Metadata["timestamp_source"]; got != "image_config" {
+		t.Errorf("latest timestamp_source = %q, want image_config", got)
+	}
 }
 
 func TestGHCRFetchWithBearerChallenge(t *testing.T) {
@@ -64,6 +90,17 @@ func TestGHCRFetchWithBearerChallenge(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"name":"sentioxyz/private","tags":["v2.0.0"]}`))
+		case "/v2/sentioxyz/private/manifests/v2.0.0":
+			if r.Header.Get("Authorization") == "" {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenURL+`",service="ghcr.io",scope="repository:sentioxyz/private:pull"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Fatalf("manifest Authorization = %q, want Bearer test-token", got)
+			}
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			_, _ = w.Write([]byte(`{"annotations":{"org.opencontainers.image.created":"2026-02-03T04:05:06Z"}}`))
 		case "/token":
 			if got := r.URL.Query().Get("service"); got != "ghcr.io" {
 				t.Fatalf("service = %q, want ghcr.io", got)
@@ -95,20 +132,93 @@ func TestGHCRFetchWithBearerChallenge(t *testing.T) {
 	}
 }
 
-func TestGHCRPagination(t *testing.T) {
-	callCount := 0
+func TestGHCRFetchTimestampFromManifestListAnnotations(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
 		w.Header().Set("Content-Type", "application/json")
-		if callCount == 1 {
-			w.Header().Set("Link", `</v2/sentioxyz/changelogue/tags/list?n=100&last=v1.0.0>; rel="next"`)
-			_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["v1.0.0"]}`))
-			return
+		switch r.URL.Path {
+		case "/v2/sentioxyz/changelogue/tags/list":
+			_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["multi"]}`))
+		case "/v2/sentioxyz/changelogue/manifests/multi":
+			_, _ = w.Write([]byte(`{
+				"manifests": [
+					{"annotations":{"org.opencontainers.image.created":"2026-03-01T00:00:00Z"}},
+					{"annotations":{"org.opencontainers.image.created":"2026-03-02T00:00:00Z"}}
+				]
+			}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("last"); got != "v1.0.0" {
-			t.Fatalf("last = %q, want v1.0.0", got)
+	}))
+	defer srv.Close()
+
+	src := NewGHCRSource(srv.Client(), "sentioxyz/changelogue", "")
+	src.baseURL = srv.URL
+
+	results, err := src.FetchNewReleases(context.Background())
+	if err != nil {
+		t.Fatalf("FetchNewReleases: %v", err)
+	}
+	expected, _ := time.Parse(time.RFC3339, "2026-03-02T00:00:00Z")
+	if !results[0].Timestamp.Equal(expected) {
+		t.Fatalf("timestamp = %v, want %v", results[0].Timestamp, expected)
+	}
+	if got := results[0].Metadata["timestamp_source"]; got != "manifest_list_annotation" {
+		t.Fatalf("timestamp_source = %q", got)
+	}
+}
+
+func TestGHCRFetchTimestampUnavailableDoesNotUseFetchTime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/sentioxyz/changelogue/tags/list":
+			_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["unknown"]}`))
+		case "/v2/sentioxyz/changelogue/manifests/unknown":
+			_, _ = w.Write([]byte(`{"schemaVersion":2}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
-		_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["v2.0.0"]}`))
+	}))
+	defer srv.Close()
+
+	src := NewGHCRSource(srv.Client(), "sentioxyz/changelogue", "")
+	src.baseURL = srv.URL
+
+	results, err := src.FetchNewReleases(context.Background())
+	if err != nil {
+		t.Fatalf("FetchNewReleases: %v", err)
+	}
+	if !results[0].Timestamp.IsZero() {
+		t.Fatalf("timestamp = %v, want zero when metadata is unavailable", results[0].Timestamp)
+	}
+	if got := results[0].Metadata["timestamp_source"]; got != "unavailable" {
+		t.Fatalf("timestamp_source = %q", got)
+	}
+}
+
+func TestGHCRPagination(t *testing.T) {
+	tagsCallCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/sentioxyz/changelogue/tags/list":
+			tagsCallCount++
+			if tagsCallCount == 1 {
+				w.Header().Set("Link", `</v2/sentioxyz/changelogue/tags/list?n=100&last=v1.0.0>; rel="next"`)
+				_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["v1.0.0"]}`))
+				return
+			}
+			if got := r.URL.Query().Get("last"); got != "v1.0.0" {
+				t.Fatalf("last = %q, want v1.0.0", got)
+			}
+			_, _ = w.Write([]byte(`{"name":"sentioxyz/changelogue","tags":["v2.0.0"]}`))
+		case "/v2/sentioxyz/changelogue/manifests/v1.0.0":
+			_, _ = w.Write([]byte(`{"annotations":{"org.opencontainers.image.created":"2026-01-01T00:00:00Z"}}`))
+		case "/v2/sentioxyz/changelogue/manifests/v2.0.0":
+			_, _ = w.Write([]byte(`{"annotations":{"org.opencontainers.image.created":"2026-02-01T00:00:00Z"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- stop using fetch time as the GHCR release timestamp
- fetch each GHCR tag manifest/config and derive timestamps from OCI metadata when available
- mark GHCR timestamps as unavailable when the registry metadata does not expose a published/build time

## Details
The GHCR tags endpoint only returns tag names. The provider now uses tag manifests/config blobs to read timestamps from:
- `org.opencontainers.image.created` and related labels
- image config `created`
- image config history timestamps
- child manifest annotations for manifest lists

## Verification
- `go test ./internal/ingestion -run 'TestGHCR|TestParseBearerChallenge'`
- `go test ./internal/ingestion ./internal/api ./internal/routing`
- `go test ./...`
- `npm run lint` (existing warnings only)
- `npm run build` (first run installed missing deps and hit a transient Next.js prerender invariant; rerun passed)
- Go binary builds for server, CLI, and stealth
- `git diff --check`
