### PR TITLE
Retry notify job when TODO creation fails

### DIFF
--- a/internal/routing/worker.go
+++ b/internal/routing/worker.go
@@ -82,6 +82,12 @@ func VersionPassesFilter(version string, include, exclude *string) bool {
 // sends notifications to all matching channels, and checks agent rules to
 // auto-trigger agent runs when version criteria are met.
 func (w *NotifyWorker) Work(ctx context.Context, job *river.Job[queue.NotifyJobArgs]) error {
+	slog.Info("notify_release started", notifyLogAttrs(job,
+		"release_id", job.Args.ReleaseID,
+		"source_id", job.Args.SourceID,
+		"is_update", job.Args.IsUpdate,
+	)...)
+
 	release, err := w.store.GetRelease(ctx, job.Args.ReleaseID)
 	if err != nil {
 		return fmt.Errorf("get release: %w", err)
@@ -93,7 +99,13 @@ func (w *NotifyWorker) Work(ctx context.Context, job *river.Job[queue.NotifyJobA
 		return fmt.Errorf("get source: %w", err)
 	}
 	if !VersionPassesFilter(release.Version, source.VersionFilterInclude, source.VersionFilterExclude) {
-		slog.Debug("release filtered by version filter", "version", release.Version, "source_id", job.Args.SourceID)
+		slog.Info("notify_release skipped by version filter", notifyLogAttrs(job,
+			"release_id", release.ID,
+			"source_id", job.Args.SourceID,
+			"version", release.Version,
+			"include_filter", stringValue(source.VersionFilterInclude),
+			"exclude_filter", stringValue(source.VersionFilterExclude),
+		)...)
 		return nil
 	}
 
@@ -102,34 +114,67 @@ func (w *NotifyWorker) Work(ctx context.Context, job *river.Job[queue.NotifyJobA
 		var rawData map[string]interface{}
 		if err := json.Unmarshal(release.RawData, &rawData); err == nil {
 			if prerelease, _ := rawData["prerelease"].(string); prerelease == "true" {
-				slog.Debug("release filtered by exclude_prereleases", "version", release.Version, "source_id", job.Args.SourceID)
+				slog.Info("notify_release skipped by exclude_prereleases", notifyLogAttrs(job,
+					"release_id", release.ID,
+					"source_id", job.Args.SourceID,
+					"version", release.Version,
+				)...)
 				return nil
 			}
 		}
 	}
 
-	// Create a TODO for this release (idempotent — safe for retries).
+	// Create a TODO before external sends. This is idempotent and failing here
+	// makes River retry instead of silently completing without the TODO side effect.
 	todoID, todoErr := w.store.CreateReleaseTodo(ctx, release.ID)
 	if todoErr != nil {
-		slog.Error("create release todo failed", "release_id", release.ID, "err", todoErr)
-		// Continue — notification delivery is primary responsibility.
+		slog.Error("create release todo failed", notifyLogAttrs(job,
+			"release_id", release.ID,
+			"source_id", job.Args.SourceID,
+			"version", release.Version,
+			"err", todoErr,
+		)...)
+		return fmt.Errorf("create release todo: %w", todoErr)
 	}
+	slog.Info("release todo verified", notifyLogAttrs(job,
+		"release_id", release.ID,
+		"source_id", job.Args.SourceID,
+		"version", release.Version,
+		"todo_id", todoID,
+	)...)
 
 	subs, err := w.store.ListSourceSubscriptions(ctx, job.Args.SourceID)
 	if err != nil {
 		return fmt.Errorf("list subscriptions: %w", err)
 	}
+	slog.Info("notify_release subscriptions loaded", notifyLogAttrs(job,
+		"release_id", release.ID,
+		"source_id", job.Args.SourceID,
+		"subscription_count", len(subs),
+	)...)
 
 	for _, sub := range subs {
 		ch, err := w.store.GetChannel(ctx, sub.ChannelID)
 		if err != nil {
-			slog.Error("get channel failed", "channel_id", sub.ChannelID, "err", err)
+			slog.Error("get channel failed", notifyLogAttrs(job,
+				"release_id", release.ID,
+				"source_id", job.Args.SourceID,
+				"subscription_id", sub.ID,
+				"channel_id", sub.ChannelID,
+				"err", err,
+			)...)
 			continue
 		}
 
 		sender, ok := w.senders[ch.Type]
 		if !ok {
-			slog.Warn("unknown channel type", "type", ch.Type)
+			slog.Warn("unknown channel type", notifyLogAttrs(job,
+				"release_id", release.ID,
+				"source_id", job.Args.SourceID,
+				"subscription_id", sub.ID,
+				"channel_id", ch.ID,
+				"channel_type", ch.Type,
+			)...)
 			continue
 		}
 
@@ -160,14 +205,55 @@ func (w *NotifyWorker) Work(ctx context.Context, job *river.Job[queue.NotifyJobA
 		}
 
 		if err := sender.Send(ctx, ch, msg); err != nil {
-			slog.Error("send notification failed", "channel", ch.Name, "err", err)
+			slog.Error("send notification failed", notifyLogAttrs(job,
+				"release_id", release.ID,
+				"source_id", job.Args.SourceID,
+				"subscription_id", sub.ID,
+				"channel_id", ch.ID,
+				"channel", ch.Name,
+				"channel_type", ch.Type,
+				"err", err,
+			)...)
+		} else {
+			slog.Info("notification sent", notifyLogAttrs(job,
+				"release_id", release.ID,
+				"source_id", job.Args.SourceID,
+				"subscription_id", sub.ID,
+				"channel_id", ch.ID,
+				"channel", ch.Name,
+				"channel_type", ch.Type,
+				"todo_id", todoID,
+			)...)
 		}
 	}
 
 	// Check agent rules and auto-trigger if criteria are met.
 	w.checkAgentRules(ctx, release, source)
 
+	slog.Info("notify_release completed", notifyLogAttrs(job,
+		"release_id", release.ID,
+		"source_id", job.Args.SourceID,
+		"version", release.Version,
+		"todo_id", todoID,
+		"subscription_count", len(subs),
+	)...)
+
 	return nil
+}
+
+func notifyLogAttrs(job *river.Job[queue.NotifyJobArgs], attrs ...any) []any {
+	if job.JobRow == nil {
+		return attrs
+	}
+	base := []any{"job_id", job.ID, "attempt", job.Attempt}
+	return append(base, attrs...)
+}
+
+func stringValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // checkAgentRules evaluates the project's agent rules against the new release

--- a/internal/routing/worker_test.go
+++ b/internal/routing/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -27,6 +28,7 @@ type mockNotifyStore struct {
 	mu              sync.Mutex
 	agentRunCalls   []agentRunCall
 	enqueueAgentErr error
+	createTodoErr   error
 }
 
 type agentRunCall struct {
@@ -112,6 +114,9 @@ func (m *mockNotifyStore) EnqueueAgentRun(_ context.Context, projectID, trigger,
 func (m *mockNotifyStore) CreateReleaseTodo(_ context.Context, releaseID string) (string, error) {
 	if m.err != nil {
 		return "", m.err
+	}
+	if m.createTodoErr != nil {
+		return "", m.createTodoErr
 	}
 	return "todo-" + releaseID, nil
 }
@@ -445,6 +450,51 @@ func TestNotifyWorker_SenderError(t *testing.T) {
 	err := worker.Work(context.Background(), job)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNotifyWorker_TodoCreationFailureRetriesBeforeSending(t *testing.T) {
+	sourceID := "src-1"
+	releaseID := "rel-1"
+
+	store := &mockNotifyStore{
+		releases: map[string]*models.Release{
+			releaseID: {ID: releaseID, SourceID: sourceID, Version: "v1.0.0", RawData: json.RawMessage(`{}`)},
+		},
+		sources: map[string]*models.Source{
+			sourceID: {ID: sourceID, ProjectID: "proj-1"},
+		},
+		subscriptions: map[string][]models.Subscription{
+			sourceID: {{ID: "sub-1", ChannelID: "ch-1", Type: "source_release", SourceID: &sourceID}},
+		},
+		channels: map[string]*models.NotificationChannel{
+			"ch-1": {ID: "ch-1", Name: "test", Type: "webhook", Config: json.RawMessage(`{"url":"http://example.com"}`)},
+		},
+		projects: map[string]*models.Project{
+			"proj-1": {ID: "proj-1", Name: "test", AgentRules: json.RawMessage(`{}`)},
+		},
+		createTodoErr: errors.New("insert release todo failed"),
+	}
+
+	webhookSender := &mockSender{}
+	worker := &NotifyWorker{
+		store:   store,
+		senders: map[string]Sender{"webhook": webhookSender},
+	}
+
+	job := &river.Job[queue.NotifyJobArgs]{
+		Args: queue.NotifyJobArgs{ReleaseID: releaseID, SourceID: sourceID},
+	}
+
+	err := worker.Work(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected todo creation error to make notify job retry")
+	}
+	if !strings.Contains(err.Error(), "create release todo") {
+		t.Fatalf("expected create release todo error, got %v", err)
+	}
+	if webhookSender.sentCount() != 0 {
+		t.Fatalf("expected 0 notifications before TODO side effect succeeds, got %d", webhookSender.sentCount())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make `notify_release` fail before notification sends when release TODO creation fails, so River retries the same job.
- Add structured notify-worker logs for start, filter skips, TODO verification, subscription count, send success/failure, and completion.
- Add a regression test that proves TODO failure returns an error and sends no notifications.

## Test Plan
- `go test ./internal/routing -run TestNotifyWorker_TodoCreationFailureRetriesBeforeSending -count=1`
- `go test ./internal/routing`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
